### PR TITLE
Fix CI: Node 22 + Prettier formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -40,7 +40,10 @@ const projects = defineCollection({
         z.object({
           title: z.string(),
           description: z.string(),
-          icon: z.string().optional().describe("Icon identifier from the design system"),
+          icon: z
+            .string()
+            .optional()
+            .describe("Icon identifier from the design system"),
         }),
       )
       .default([]),

--- a/src/content/STYLE_GUIDE.md
+++ b/src/content/STYLE_GUIDE.md
@@ -12,12 +12,12 @@ consistent, respectful, and accessible voice.
 researchers to curious first-time visitors. Our tone balances academic precision
 with warmth and clarity.
 
-| Do | Don't |
-|---|---|
-| Explain technical terms on first use | Assume readers know Arabic terminology |
-| Use clear, direct sentences | Use jargon-heavy or overly formal language |
-| Show respect for Islamic tradition | Treat religious sources casually |
-| Invite the reader in | Lecture or gatekeep |
+| Do                                   | Don't                                      |
+| ------------------------------------ | ------------------------------------------ |
+| Explain technical terms on first use | Assume readers know Arabic terminology     |
+| Use clear, direct sentences          | Use jargon-heavy or overly formal language |
+| Show respect for Islamic tradition   | Treat religious sources casually           |
+| Invite the reader in                 | Lecture or gatekeep                        |
 
 ### Key Principles
 
@@ -117,9 +117,9 @@ Until then, all content lives at the collection root without a locale prefix.
 ## Arabic Terms and Transliteration
 
 - On first use, provide the Arabic term followed by a brief English definition:
-  *isnad* (chain of narration).
-- Use standard academic transliteration where practical (e.g., *hadith*, not
-  *hadeeth*).
+  _isnad_ (chain of narration).
+- Use standard academic transliteration where practical (e.g., _hadith_, not
+  _hadeeth_).
 - Wrap Arabic-script text in `<span lang="ar">` for correct directionality.
 
 ---
@@ -127,7 +127,7 @@ Until then, all content lives at the collection root without a locale prefix.
 ## Formatting Conventions
 
 - **Bold** for emphasis — use sparingly.
-- *Italics* for Arabic transliterations and foreign terms.
+- _Italics_ for Arabic transliterations and foreign terms.
 - Use ordered lists (`1.`) for sequential steps; unordered lists (`-`) for
   non-sequential items.
 - One sentence per line in MDX source for cleaner diffs.

--- a/src/content/routes.md
+++ b/src/content/routes.md
@@ -6,10 +6,10 @@ Documented route structure for the NoorinALabs landing page.
 
 ## Route Map
 
-| Route | Source | Layout | Collection | Description |
-|-------|--------|--------|------------|-------------|
-| `/` | `src/pages/index.astro` | `PageLayout` | — | Homepage: hero, mission statement, project showcase cards |
-| `/about` | `src/pages/about.astro` | `PageLayout` | `pages` | Mission page: renders `src/content/pages/about.mdx` |
+| Route                   | Source                               | Layout          | Collection | Description                                                          |
+| ----------------------- | ------------------------------------ | --------------- | ---------- | -------------------------------------------------------------------- |
+| `/`                     | `src/pages/index.astro`              | `PageLayout`    | —          | Homepage: hero, mission statement, project showcase cards            |
+| `/about`                | `src/pages/about.astro`              | `PageLayout`    | `pages`    | Mission page: renders `src/content/pages/about.mdx`                  |
 | `/projects/isnad-graph` | `src/pages/projects/[...slug].astro` | `ProjectLayout` | `projects` | Project feature page: renders `src/content/projects/isnad-graph.mdx` |
 
 ---
@@ -47,10 +47,10 @@ BaseLayout.astro
 
 ### Header Navigation
 
-| Label | Href | Notes |
-|-------|------|-------|
-| Home | `/` | Always visible |
-| About | `/about` | |
+| Label    | Href         | Notes                                           |
+| -------- | ------------ | ----------------------------------------------- |
+| Home     | `/`          | Always visible                                  |
+| About    | `/about`     |                                                 |
 | Projects | `/#projects` | Scrolls to project showcase section on homepage |
 
 ### Footer Links
@@ -72,8 +72,8 @@ BaseLayout.astro
 
 These routes are anticipated but not yet implemented:
 
-| Route | Description |
-|-------|-------------|
-| `/projects/[slug]` | Additional project pages as new tools launch |
-| `/blog` | Devlog or research notes (content collection: `blog`) |
-| `/ar/...` | Arabic-language mirror (i18n expansion) |
+| Route              | Description                                           |
+| ------------------ | ----------------------------------------------------- |
+| `/projects/[slug]` | Additional project pages as new tools launch          |
+| `/blog`            | Devlog or research notes (content collection: `blog`) |
+| `/ar/...`          | Arabic-language mirror (i18n expansion)               |

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,9 @@ const {
 
 const siteUrl = Astro.site?.toString().replace(/\/$/, "") ?? "";
 const canonical = canonicalUrl ?? Astro.url.href;
-const resolvedOgImage = ogImage.startsWith("http") ? ogImage : `${siteUrl}${ogImage}`;
+const resolvedOgImage = ogImage.startsWith("http")
+  ? ogImage
+  : `${siteUrl}${ogImage}`;
 ---
 
 <!doctype html>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -31,9 +31,7 @@ const headerNav = [
 ];
 
 const footerNav = {
-  projects: [
-    { label: "Isnad Graph", href: "/projects/isnad-graph" },
-  ],
+  projects: [{ label: "Isnad Graph", href: "/projects/isnad-graph" }],
   organization: [
     { label: "About", href: "/about" },
     { label: "GitHub", href: "https://github.com/noorinalabs" },
@@ -41,7 +39,12 @@ const footerNav = {
 };
 ---
 
-<BaseLayout title={title} description={description} ogImage={ogImage} ogImageAlt={ogImageAlt}>
+<BaseLayout
+  title={title}
+  description={description}
+  ogImage={ogImage}
+  ogImageAlt={ogImageAlt}
+>
   <slot name="head" slot="head" />
 
   <!-- Header -->
@@ -53,11 +56,13 @@ const footerNav = {
       </a>
 
       <ul role="list">
-        {headerNav.map((item) => (
-          <li>
-            <a href={item.href}>{item.label}</a>
-          </li>
-        ))}
+        {
+          headerNav.map((item) => (
+            <li>
+              <a href={item.href}>{item.label}</a>
+            </li>
+          ))
+        }
       </ul>
     </nav>
   </header>
@@ -73,18 +78,26 @@ const footerNav = {
       <div>
         <h2 class="footer-heading">Projects</h2>
         <ul role="list">
-          {footerNav.projects.map((item) => (
-            <li><a href={item.href}>{item.label}</a></li>
-          ))}
+          {
+            footerNav.projects.map((item) => (
+              <li>
+                <a href={item.href}>{item.label}</a>
+              </li>
+            ))
+          }
         </ul>
       </div>
 
       <div>
         <h2 class="footer-heading">Organization</h2>
         <ul role="list">
-          {footerNav.organization.map((item) => (
-            <li><a href={item.href}>{item.label}</a></li>
-          ))}
+          {
+            footerNav.organization.map((item) => (
+              <li>
+                <a href={item.href}>{item.label}</a>
+              </li>
+            ))
+          }
         </ul>
       </div>
     </div>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -32,10 +32,22 @@ interface Props {
   cta?: CTA;
 }
 
-const { title, description, ogImage, ogImageAlt, features = [], cta } = Astro.props;
+const {
+  title,
+  description,
+  ogImage,
+  ogImageAlt,
+  features = [],
+  cta,
+} = Astro.props;
 ---
 
-<PageLayout title={title} description={description} ogImage={ogImage} ogImageAlt={ogImageAlt}>
+<PageLayout
+  title={title}
+  description={description}
+  ogImage={ogImage}
+  ogImageAlt={ogImageAlt}
+>
   <slot name="head" slot="head" />
 
   <!-- Hero -->
@@ -43,25 +55,33 @@ const { title, description, ogImage, ogImageAlt, features = [], cta } = Astro.pr
     <h1 id="project-title">{title}</h1>
     <p class="project-description">{description}</p>
 
-    {cta && (
-      <a href={cta.href} class="cta-button" role="link">
-        {cta.label}
-      </a>
-    )}
+    {
+      cta && (
+        <a href={cta.href} class="cta-button" role="link">
+          {cta.label}
+        </a>
+      )
+    }
   </section>
 
   <!-- Features grid -->
-  {features.length > 0 && (
-    <section class="features-grid" aria-label="Key features">
-      {features.map((feature) => (
-        <article class="feature-card">
-          {feature.icon && <span class="feature-icon" aria-hidden="true">{feature.icon}</span>}
-          <h2>{feature.title}</h2>
-          <p>{feature.description}</p>
-        </article>
-      ))}
-    </section>
-  )}
+  {
+    features.length > 0 && (
+      <section class="features-grid" aria-label="Key features">
+        {features.map((feature) => (
+          <article class="feature-card">
+            {feature.icon && (
+              <span class="feature-icon" aria-hidden="true">
+                {feature.icon}
+              </span>
+            )}
+            <h2>{feature.title}</h2>
+            <p>{feature.description}</p>
+          </article>
+        ))}
+      </section>
+    )
+  }
 
   <!-- MDX body content -->
   <section class="project-content prose">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,8 +45,8 @@ import SEO from "../components/SEO.astro";
           </p>
           <p>
             NoorinALabs builds open-source tools that bring modern computational
-            methods to this tradition — not to replace scholarly judgment, but to
-            make the underlying data more accessible and the connections more
+            methods to this tradition — not to replace scholarly judgment, but
+            to make the underlying data more accessible and the connections more
             visible.
           </p>
         </div>
@@ -80,30 +80,14 @@ import SEO from "../components/SEO.astro";
             width="64"
             height="64"
           >
-            <circle
-              cx="32"
-              cy="12"
-              r="6"
-              stroke="currentColor"
-              stroke-width="2"></circle>
-            <circle
-              cx="12"
-              cy="44"
-              r="6"
-              stroke="currentColor"
-              stroke-width="2"></circle>
-            <circle
-              cx="52"
-              cy="44"
-              r="6"
-              stroke="currentColor"
-              stroke-width="2"></circle>
-            <circle
-              cx="32"
-              cy="52"
-              r="4"
-              stroke="currentColor"
-              stroke-width="2"></circle>
+            <circle cx="32" cy="12" r="6" stroke="currentColor" stroke-width="2"
+            ></circle>
+            <circle cx="12" cy="44" r="6" stroke="currentColor" stroke-width="2"
+            ></circle>
+            <circle cx="52" cy="44" r="6" stroke="currentColor" stroke-width="2"
+            ></circle>
+            <circle cx="32" cy="52" r="4" stroke="currentColor" stroke-width="2"
+            ></circle>
             <line
               x1="32"
               y1="18"


### PR DESCRIPTION
## Summary
- Update `.github/workflows/ci.yml` to use Node 22 (Astro 6 requires >= 22.12.0)
- Run Prettier on 7 source files that failed the format check

## Files changed
- `.github/workflows/ci.yml` — node-version 20 → 22
- `src/content.config.ts`, `src/content/routes.md`, `src/content/STYLE_GUIDE.md` — formatting
- `src/layouts/BaseLayout.astro`, `src/layouts/PageLayout.astro`, `src/layouts/ProjectLayout.astro` — formatting
- `src/pages/index.astro` — formatting

## Test plan
- [x] `npm run build` passes locally
- [x] `npx prettier --check` passes locally
- [ ] CI passes on this PR

Fixes CI failures on PR #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)