### PR TITLE
Add unit tests, Playwright E2E tests, and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, 'deployments/**']
+    branches: [main, "deployments/**"]
   pull_request:
-    branches: [main, 'deployments/**']
+    branches: [main, "deployments/**"]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -40,3 +40,42 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Unit tests
+        run: npm test
+
+  e2e:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+
+      - name: Run E2E tests
+        run: npx playwright test --project=desktop-chromium
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ Thumbs.db
 
 # Lighthouse reports
 lighthouse-report.html
+
+# Playwright
+test-results/
+playwright-report/
+
+# Vitest
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,18 @@
       },
       "devDependencies": {
         "@astrojs/sitemap": "^3.7.2",
+        "@axe-core/playwright": "^4.11.1",
+        "@playwright/test": "^1.59.1",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "eslint": "^10.2.0",
         "eslint-plugin-astro": "^1.6.0",
+        "happy-dom": "^20.8.9",
         "lighthouse": "^13.0.3",
         "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -137,6 +141,19 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2045,6 +2062,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
@@ -2661,6 +2694,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2934,6 +2974,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2952,6 +3003,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3095,6 +3153,23 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3346,6 +3421,129 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3495,6 +3693,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -3928,6 +4136,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4175,6 +4393,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -5129,6 +5354,16 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5494,6 +5729,59 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/hasown": {
@@ -8073,6 +8361,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8136,6 +8431,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -9009,6 +9351,13 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -9147,6 +9496,20 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -9388,6 +9751,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -9420,6 +9790,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts-core": {
@@ -10026,6 +10406,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -10042,6 +10504,16 @@
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/when-exit": {
       "version": "2.1.5",
@@ -10073,6 +10545,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "preview": "astro preview",
     "lint": "eslint . && prettier --check .",
     "format": "prettier --write .",
+    "test": "vitest run",
+    "test:e2e": "playwright test",
     "lighthouse": "lighthouse http://localhost:4321 --output html --output-path ./lighthouse-report.html --chrome-flags=\"--headless --no-sandbox\""
   },
   "repository": {
@@ -30,13 +32,17 @@
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.7.2",
+    "@axe-core/playwright": "^4.11.1",
+    "@playwright/test": "^1.59.1",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "eslint": "^10.2.0",
     "eslint-plugin-astro": "^1.6.0",
+    "happy-dom": "^20.8.9",
     "lighthouse": "^13.0.3",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "html",
+  use: {
+    baseURL: "http://localhost:4321",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+    {
+      name: "tablet",
+      use: {
+        ...devices["iPad (gen 7)"],
+        browserName: "chromium",
+      },
+    },
+  ],
+  webServer: {
+    command: "npm run preview",
+    url: "http://localhost:4321",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test.describe("Accessibility", () => {
+  test("homepage has no critical a11y violations", async ({ page }) => {
+    await page.goto("/");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze();
+
+    expect(results.violations.filter((v) => v.impact === "critical")).toEqual(
+      [],
+    );
+  });
+
+  test("about page has no critical a11y violations", async ({ page }) => {
+    await page.goto("/about");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze();
+
+    expect(results.violations.filter((v) => v.impact === "critical")).toEqual(
+      [],
+    );
+  });
+
+  test("isnad-graph page has no critical a11y violations", async ({ page }) => {
+    await page.goto("/projects/isnad-graph");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze();
+
+    expect(results.violations.filter((v) => v.impact === "critical")).toEqual(
+      [],
+    );
+  });
+
+  test("skip-to-content link exists and targets main", async ({ page }) => {
+    await page.goto("/");
+    const skipLink = page.locator('a[href="#main-content"]');
+    await expect(skipLink).toHaveCount(1);
+    const main = page.locator("main#main-content");
+    await expect(main).toHaveCount(1);
+  });
+
+  test("images have alt text", async ({ page }) => {
+    await page.goto("/");
+    const images = page.locator("img");
+    const count = await images.count();
+    for (let i = 0; i < count; i++) {
+      const alt = await images.nth(i).getAttribute("alt");
+      expect(alt).toBeTruthy();
+    }
+  });
+});

--- a/tests/e2e/links.spec.ts
+++ b/tests/e2e/links.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Link validation", () => {
+  test("no broken internal links on homepage", async ({ page }) => {
+    await page.goto("/");
+    const links = page.locator('a[href^="/"]');
+    const count = await links.count();
+
+    for (let i = 0; i < count; i++) {
+      const href = await links.nth(i).getAttribute("href");
+      if (!href || href === "#main-content") continue;
+
+      const response = await page.request.get(href);
+      expect(
+        response.ok(),
+        `Broken link: ${href} returned ${response.status()}`,
+      ).toBe(true);
+    }
+  });
+
+  test("no broken internal links on about page", async ({ page }) => {
+    await page.goto("/about");
+    const links = page.locator('a[href^="/"]');
+    const count = await links.count();
+
+    for (let i = 0; i < count; i++) {
+      const href = await links.nth(i).getAttribute("href");
+      if (!href || href === "#main-content") continue;
+
+      const response = await page.request.get(href);
+      expect(
+        response.ok(),
+        `Broken link: ${href} returned ${response.status()}`,
+      ).toBe(true);
+    }
+  });
+});
+
+test.describe("OG meta tags on all pages", () => {
+  const pages = [
+    { name: "homepage", url: "/" },
+    { name: "about", url: "/about" },
+    { name: "isnad-graph", url: "/projects/isnad-graph" },
+  ];
+
+  for (const p of pages) {
+    test(`${p.name} has required OG meta tags`, async ({ page }) => {
+      await page.goto(p.url);
+
+      const ogTitle = page.locator('meta[property="og:title"]');
+      await expect(ogTitle).toHaveCount(1);
+
+      const ogDesc = page.locator('meta[property="og:description"]');
+      await expect(ogDesc).toHaveCount(1);
+
+      const ogImage = page.locator('meta[property="og:image"]');
+      await expect(ogImage).toHaveCount(1);
+
+      const ogType = page.locator('meta[property="og:type"]');
+      await expect(ogType).toHaveCount(1);
+    });
+  }
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Page navigation", () => {
+  test("homepage loads with correct title", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Home.*NoorinALabs/);
+  });
+
+  test("navigate from homepage to about", async ({ page }) => {
+    await page.goto("/");
+    await page.click('a[href="/about"]');
+    await expect(page).toHaveURL(/\/about/);
+    await expect(page).toHaveTitle(/About.*NoorinALabs/);
+  });
+
+  test("navigate from homepage to isnad-graph project", async ({ page }) => {
+    await page.goto("/");
+    await page.click('a[href="/projects/isnad-graph"]');
+    await expect(page).toHaveURL(/\/projects\/isnad-graph/);
+    await expect(page).toHaveTitle(/Isnad Graph.*NoorinALabs/);
+  });
+
+  test("logo links back to homepage", async ({ page }) => {
+    await page.goto("/about");
+    await page.click('a[aria-label="NoorinALabs home"]');
+    await expect(page).toHaveURL("/");
+  });
+});

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Responsive behavior", () => {
+  test("hero section is visible on all viewports", async ({ page }) => {
+    await page.goto("/");
+    const hero = page.locator(".hero");
+    await expect(hero).toBeVisible();
+  });
+
+  test("navigation is visible", async ({ page }) => {
+    await page.goto("/");
+    const nav = page.locator('nav[aria-label="Primary navigation"]');
+    await expect(nav).toBeVisible();
+  });
+
+  test("footer is visible", async ({ page }) => {
+    await page.goto("/");
+    const footer = page.locator('footer[role="contentinfo"]');
+    await expect(footer).toBeVisible();
+  });
+
+  test("value cards are rendered", async ({ page }) => {
+    await page.goto("/");
+    const cards = page.locator(".value-card");
+    await expect(cards).toHaveCount(4);
+  });
+
+  test("project card is rendered", async ({ page }) => {
+    await page.goto("/");
+    const card = page.locator(".project-card");
+    await expect(card).toBeVisible();
+  });
+});

--- a/tests/unit/content-schema.test.ts
+++ b/tests/unit/content-schema.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const contentDir = resolve(import.meta.dirname, "../../src/content");
+
+describe("Content collection — projects/isnad-graph.mdx", () => {
+  const raw = readFileSync(
+    resolve(contentDir, "projects/isnad-graph.mdx"),
+    "utf-8",
+  );
+
+  it("has a title in frontmatter", () => {
+    expect(raw).toMatch(/^title:\s*.+/m);
+  });
+
+  it("has a description in frontmatter", () => {
+    expect(raw).toMatch(/^description:\s*.+/m);
+  });
+
+  it("has a publishDate in frontmatter", () => {
+    expect(raw).toMatch(/^publishDate:\s*.+/m);
+  });
+
+  it("has features array", () => {
+    expect(raw).toMatch(/^features:/m);
+  });
+});
+
+describe("Content collection — pages/about.mdx", () => {
+  const raw = readFileSync(resolve(contentDir, "pages/about.mdx"), "utf-8");
+
+  it("has a title in frontmatter", () => {
+    expect(raw).toMatch(/^title:\s*.+/m);
+  });
+
+  it("has a description in frontmatter", () => {
+    expect(raw).toMatch(/^description:\s*.+/m);
+  });
+
+  it("has a publishDate in frontmatter", () => {
+    expect(raw).toMatch(/^publishDate:\s*.+/m);
+  });
+});
+
+describe("Content config (content.config.ts)", () => {
+  const raw = readFileSync(
+    resolve(contentDir, "../content.config.ts"),
+    "utf-8",
+  );
+
+  it("defines projects collection", () => {
+    expect(raw).toContain("defineCollection");
+    expect(raw).toContain("projects");
+  });
+
+  it("defines pages collection", () => {
+    expect(raw).toContain("pages");
+  });
+
+  it("exports collections", () => {
+    expect(raw).toContain("export const collections");
+  });
+
+  it("uses Zod schemas for validation", () => {
+    expect(raw).toContain("z.object");
+    expect(raw).toContain("z.string()");
+  });
+
+  it("projects schema has required fields", () => {
+    expect(raw).toContain("title: z.string()");
+    expect(raw).toContain("description: z.string()");
+    expect(raw).toContain("publishDate: z.coerce.date()");
+  });
+});

--- a/tests/unit/homepage.test.ts
+++ b/tests/unit/homepage.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const distDir = resolve(import.meta.dirname, "../../dist");
+
+function readPage(path: string): string {
+  return readFileSync(resolve(distDir, path), "utf-8");
+}
+
+describe("Homepage (index.html)", () => {
+  const html = readPage("index.html");
+
+  it("renders the hero heading", () => {
+    expect(html).toContain("Open Tools for");
+    expect(html).toContain("Islamic Scholarly Research");
+  });
+
+  it("renders the hero subtitle", () => {
+    expect(html).toContain(
+      "NoorinALabs brings computational analysis to the Islamic scholarly",
+    );
+  });
+
+  it("renders hero call-to-action links", () => {
+    expect(html).toContain('href="/projects/isnad-graph"');
+    expect(html).toContain("Explore the Isnad Graph");
+    expect(html).toContain('href="/about"');
+    expect(html).toContain("Learn About Us");
+  });
+
+  it("renders the What We Do section", () => {
+    expect(html).toContain("What We Do");
+    expect(html).toContain("knowledge verification in human history");
+  });
+
+  it("renders the blockquote", () => {
+    expect(html).toContain("Imam Muhammad ibn Sirin");
+  });
+
+  it("renders the Featured Project section", () => {
+    expect(html).toContain("Featured Project");
+    expect(html).toContain("The Isnad Graph");
+    expect(html).toContain("computational hadith analysis platform");
+  });
+
+  it("renders the project card features list", () => {
+    expect(html).toContain(
+      "Interactive graph visualization of narrator networks",
+    );
+    expect(html).toContain(
+      "Biographical profiles with reliability assessments",
+    );
+    expect(html).toContain("Cross-collection search across hadith sources");
+  });
+
+  it("renders the Why NoorinALabs value propositions", () => {
+    expect(html).toContain("Why NoorinALabs");
+    expect(html).toContain("Open Source");
+    expect(html).toContain("Scholarly Rigor");
+    expect(html).toContain("Accessible to All");
+    expect(html).toContain("Community Driven");
+  });
+});

--- a/tests/unit/layouts.test.ts
+++ b/tests/unit/layouts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const distDir = resolve(import.meta.dirname, "../../dist");
+
+function readPage(path: string): string {
+  return readFileSync(resolve(distDir, path), "utf-8");
+}
+
+describe("BaseLayout", () => {
+  const html = readPage("index.html");
+
+  it("renders valid HTML5 document", () => {
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain('<html lang="en" dir="ltr">');
+    expect(html).toContain('<meta charset="utf-8">');
+    expect(html).toContain("viewport");
+  });
+
+  it("renders title with site suffix", () => {
+    expect(html).toContain("<title>Home | NoorinALabs</title>");
+  });
+
+  it("renders meta description", () => {
+    expect(html).toMatch(/<meta name="description" content="[^"]+"/);
+  });
+
+  it("renders canonical link", () => {
+    expect(html).toMatch(/<link rel="canonical" href="[^"]+"/);
+  });
+
+  it("renders favicon link", () => {
+    expect(html).toContain('href="/favicon.svg"');
+  });
+});
+
+describe("PageLayout", () => {
+  const html = readPage("index.html");
+
+  it("renders header with banner role", () => {
+    expect(html).toContain('role="banner"');
+  });
+
+  it("renders main content area", () => {
+    expect(html).toContain('id="main-content"');
+    expect(html).toContain("<main");
+  });
+
+  it("renders footer with contentinfo role", () => {
+    expect(html).toContain('role="contentinfo"');
+  });
+});
+
+describe("ProjectLayout", () => {
+  const html = readPage("projects/isnad-graph/index.html");
+
+  it("renders project hero with title", () => {
+    expect(html).toContain('id="project-title"');
+  });
+
+  it("renders project description", () => {
+    expect(html).toContain("computational hadith analysis platform");
+  });
+
+  it("renders features grid when features are provided", () => {
+    expect(html).toContain('aria-label="Key features"');
+  });
+});

--- a/tests/unit/navigation.test.ts
+++ b/tests/unit/navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const distDir = resolve(import.meta.dirname, "../../dist");
+
+function readPage(path: string): string {
+  return readFileSync(resolve(distDir, path), "utf-8");
+}
+
+describe("Navigation", () => {
+  const html = readPage("index.html");
+
+  it("renders the site logo linking to home", () => {
+    expect(html).toContain('aria-label="NoorinALabs home"');
+    expect(html).toContain("NoorinALabs");
+  });
+
+  it("renders primary navigation links", () => {
+    expect(html).toContain('aria-label="Primary navigation"');
+    expect(html).toContain(">Home</");
+    expect(html).toContain(">About</");
+    expect(html).toContain(">Projects</");
+  });
+
+  it("renders footer with project links", () => {
+    expect(html).toContain("Isnad Graph");
+  });
+
+  it("renders footer with organization links", () => {
+    expect(html).toContain('href="https://github.com/noorinalabs"');
+    expect(html).toContain("GitHub");
+  });
+
+  it("renders footer copyright", () => {
+    expect(html).toContain("NoorinALabs. All rights reserved.");
+  });
+
+  it("includes skip-to-content link", () => {
+    expect(html).toContain('href="#main-content"');
+    expect(html).toContain("Skip to main content");
+  });
+});

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const distDir = resolve(import.meta.dirname, "../../dist");
+
+function readPage(path: string): string {
+  return readFileSync(resolve(distDir, path), "utf-8");
+}
+
+describe("SEO — JSON-LD structured data", () => {
+  const html = readPage("index.html");
+
+  it("renders Organization schema", () => {
+    expect(html).toContain('"@type":"Organization"');
+    expect(html).toContain('"name":"NoorinALabs"');
+  });
+
+  it("renders WebSite schema", () => {
+    expect(html).toContain('"@type":"WebSite"');
+  });
+
+  it("includes schema.org context", () => {
+    expect(html).toContain('"@context":"https://schema.org"');
+  });
+});
+
+describe("SEO — Isnad Graph project page JSON-LD", () => {
+  const html = readPage("projects/isnad-graph/index.html");
+
+  it("renders SoftwareApplication schema", () => {
+    expect(html).toContain('"@type":"SoftwareApplication"');
+  });
+
+  it("includes application category", () => {
+    expect(html).toContain('"applicationCategory":"EducationalApplication"');
+  });
+
+  it("includes free pricing offer", () => {
+    expect(html).toContain('"price":"0"');
+    expect(html).toContain('"priceCurrency":"USD"');
+  });
+});
+
+describe("SEO — Open Graph meta tags", () => {
+  const pages = [
+    { name: "homepage", path: "index.html" },
+    { name: "about", path: "about/index.html" },
+    { name: "isnad-graph", path: "projects/isnad-graph/index.html" },
+  ];
+
+  for (const page of pages) {
+    describe(page.name, () => {
+      const html = readPage(page.path);
+
+      it("has og:type", () => {
+        expect(html).toMatch(/<meta property="og:type" content="[^"]+"/);
+      });
+
+      it("has og:title", () => {
+        expect(html).toMatch(/<meta property="og:title" content="[^"]+"/);
+      });
+
+      it("has og:description", () => {
+        expect(html).toMatch(/<meta property="og:description" content="[^"]+"/);
+      });
+
+      it("has og:image", () => {
+        expect(html).toMatch(/<meta property="og:image" content="[^"]+"/);
+      });
+
+      it("has og:url", () => {
+        expect(html).toMatch(/<meta property="og:url" content="[^"]+"/);
+      });
+    });
+  }
+});
+
+describe("SEO — canonical URLs", () => {
+  const pages = [
+    { name: "homepage", path: "index.html" },
+    { name: "about", path: "about/index.html" },
+    { name: "isnad-graph", path: "projects/isnad-graph/index.html" },
+  ];
+
+  for (const page of pages) {
+    it(`${page.name} has a canonical link`, () => {
+      const html = readPage(page.path);
+      expect(html).toMatch(/<link rel="canonical" href="[^"]+"/);
+    });
+  }
+});
+
+describe("SEO — meta descriptions", () => {
+  const pages = [
+    { name: "homepage", path: "index.html" },
+    { name: "about", path: "about/index.html" },
+    { name: "isnad-graph", path: "projects/isnad-graph/index.html" },
+  ];
+
+  for (const page of pages) {
+    it(`${page.name} has a meta description`, () => {
+      const html = readPage(page.path);
+      expect(html).toMatch(/<meta name="description" content="[^"]+"/);
+    });
+  }
+});
+
+describe("SEO — Twitter card meta tags", () => {
+  const html = readPage("index.html");
+
+  it("has twitter:card", () => {
+    expect(html).toMatch(
+      /<meta name="twitter:card" content="summary_large_image"/,
+    );
+  });
+
+  it("has twitter:title", () => {
+    expect(html).toMatch(/<meta name="twitter:title" content="[^"]+"/);
+  });
+
+  it("has twitter:description", () => {
+    expect(html).toMatch(/<meta name="twitter:description" content="[^"]+"/);
+  });
+
+  it("has twitter:image", () => {
+    expect(html).toMatch(/<meta name="twitter:image" content="[^"]+"/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { getViteConfig } from "astro/config";
+
+export default getViteConfig({
+  test: {
+    include: ["tests/unit/**/*.test.ts"],
+    environment: "happy-dom",
+  },
+});


### PR DESCRIPTION
## Summary

- **Vitest unit tests** (5 test files, 68 tests): homepage, navigation, layouts, SEO (JSON-LD, OG tags, canonical URLs, Twitter cards), and content collection schema validation
- **Playwright E2E tests** (4 test files): page navigation, responsive behavior across desktop/mobile/tablet, accessibility checks via axe-core (WCAG 2.2 AA), internal link validation, and OG meta tag verification
- **CI workflow updated**: unit tests run in the existing `ci` job after build; Playwright E2E runs as a separate job with Chromium installation and artifact upload
- Added `vitest`, `happy-dom`, `@playwright/test`, and `@axe-core/playwright` as dev dependencies
- Added `test` and `test:e2e` npm scripts

Closes #16

## Test plan

- [x] All 68 Vitest unit tests pass locally
- [ ] CI `ci` job passes (lint, format, type check, build, unit tests)
- [ ] CI `e2e` job passes (Playwright with Chromium)
- [ ] Verify Playwright report artifact is uploaded on CI