### PR TITLE
Integrate @noorinalabs/design-system package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@noorinalabs:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
+        "@noorinalabs/design-system": "file:../../home/parameterization/code/noorinalabs-main/noorinalabs-design-system",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
         "tailwindcss": "^4.2.2"
@@ -28,6 +29,54 @@
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
+      }
+    },
+    "../../home/parameterization/code/noorinalabs-main/noorinalabs-design-system": {
+      "name": "@noorinalabs/design-system",
+      "version": "0.0.1",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "tailwind-merge": "^3.5.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.0",
+        "@storybook/addon-essentials": "8.6.14",
+        "@storybook/addon-interactions": "8.6.14",
+        "@storybook/addon-links": "8.6.14",
+        "@storybook/blocks": "8.6.14",
+        "@storybook/react": "8.6.14",
+        "@storybook/react-vite": "8.6.14",
+        "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
+        "@vitejs/plugin-react": "^4.7.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^9.39.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.20",
+        "happy-dom": "^20.8.9",
+        "jsdom": "^29.0.1",
+        "prettier": "^3.5.3",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "storybook": "8.6.14",
+        "tailwindcss": "^4.2.2",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.34.0",
+        "vite": "^6.4.1",
+        "vite-plugin-dts": "^4.5.4",
+        "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1458,6 +1507,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@noorinalabs/design-system": {
+      "resolved": "../../home/parameterization/code/noorinalabs-main/noorinalabs-design-system",
+      "link": true
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/noorinalabs/noorinalabs-landing-page#readme",
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
+    "@noorinalabs/design-system": "^0.0.1",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
     "tailwindcss": "^4.2.2"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,15 @@
 @import "tailwindcss";
+@import "@noorinalabs/design-system/styles.css";
 
 /*
- * Design system token integration placeholder.
- * When @noorinalabs/design-system is available, import tokens here:
- *   @import "@noorinalabs/design-system/tokens.css";
+ * Landing-page theme overrides
+ * ==============================
+ * The design system provides semantic tokens (--color-primary, --color-background, etc.)
+ * via @noorinalabs/design-system/styles.css.
+ *
+ * The landing page retains its navy/gold palette as Tailwind @theme extensions so that
+ * existing utility classes (bg-navy-800, text-gold-400, etc.) continue to work.
+ * These map to the same visual identity but are scoped to the landing page.
  */
 
 @theme {
@@ -40,7 +46,4 @@
   --color-neutral-700: #44403c;
   --color-neutral-800: #292524;
   --color-neutral-900: #1c1917;
-
-  --font-heading: "Georgia", "Times New Roman", serif;
-  --font-body: "Inter", "Segoe UI", system-ui, sans-serif;
 }


### PR DESCRIPTION
## Summary
- Configures `.npmrc` to resolve `@noorinalabs` packages from GitHub Packages registry
- Adds `@noorinalabs/design-system` as a dependency (version `^0.0.1`)
- Imports design system styles (`styles.css`) in `global.css`, bringing in all design tokens (colors, typography, spacing, shadows, radii, z-index, motion) and global utility/component styles
- Retains the landing-page-specific navy/gold/neutral Tailwind `@theme` extensions so existing utility classes continue to work
- Font stacks (`--font-heading`, `--font-body`, `--font-mono`, `--font-arabic`) are now provided by the design system via `:root`

## Test plan
- [x] `npm run build` passes (3 pages built)
- [x] `npm run test` passes (70/70 tests)
- [x] Changed files pass Prettier check
- [ ] Visual review: site should look the same or better with design system tokens applied
- [ ] Verify CI passes

Closes #21