### PR TITLE
ops: Configure production deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,38 +5,95 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: noorinalabs/noorinalabs-landing-page
+
 jobs:
-  deploy:
-    name: Deploy to Production
+  build-and-push:
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          node-version: 22
-          cache: npm
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
 
-      - name: Build
-        run: npm run build
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-      # TODO: Configure static hosting deployment
-      # Options: Vercel, Cloudflare Pages, or similar
-      # Replace this placeholder step with the appropriate deployment action
-      - name: Deploy (placeholder)
+  deploy:
+    name: Deploy to VPS
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    timeout-minutes: 10
+    environment: production
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          script: |
+            set -euo pipefail
+            cd /opt/noorinalabs-deploy
+            git fetch origin main && git reset --hard origin/main
+
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull landing
+            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d landing
+
+            echo "==> Waiting for landing service to stabilize..."
+            for i in $(seq 1 12); do
+              health=$(docker inspect --format='{{.State.Health.Status}}' noorinalabs-landing-1 2>/dev/null || echo "not_found")
+              echo "Attempt $i/12: landing=$health"
+              if [ "$health" = "healthy" ]; then echo "Landing page healthy"; break; fi
+              if [ "$i" -eq 12 ]; then
+                echo "ERROR: Landing health check failed after 60 seconds"
+                docker compose -p noorinalabs -f compose/docker-compose.prod.yml logs --tail=50 landing
+                exit 1
+              fi
+              sleep 5
+            done
+
+      - name: Report deployment status
+        if: always()
         run: |
-          echo "Build artifacts ready in dist/"
-          echo "Configure deployment target in this workflow"
+          echo "## Deploy noorinalabs-landing-page: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image:** ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Replaces placeholder deploy workflow with full GHCR build/push + VPS SSH deployment
- Builds Docker image and pushes to `ghcr.io/noorinalabs/noorinalabs-landing-page` with `latest` and SHA tags
- Deploys to VPS by SSHing in and pulling the new image via docker compose (matches isnad-graph pattern)
- Triggers automatically after CI passes on main, or via manual dispatch
- Dockerfile verified: builds and serves pages via nginx on port 80

Closes #30

## Required Secrets/Vars
- `DEPLOY_SSH_PRIVATE_KEY` — SSH key for VPS access
- `VPS_HOST` — VPS hostname (repository variable)
- `GITHUB_TOKEN` — automatic, for GHCR login

## Test Plan
- [x] Docker build succeeds locally
- [ ] CI passes on this PR
- [ ] After merge, deploy workflow triggers and pushes image to GHCR
- [ ] VPS pulls and serves landing page

Co-Authored-By: Kofi Mensah-Williams <parametrization+Kofi.Mensah-Williams@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>