### PR TITLE
fix: broken nav, redundant footer emails, hero pillar styling

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,9 +21,9 @@ server {
         add_header Cache-Control "public, must-revalidate";
     }
 
-    # SPA fallback — serve index.html for unknown routes
+    # Static site routing — serve pre-rendered pages, 404 for unknowns
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ $uri/index.html =404;
     }
 
     # Security headers

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -38,7 +38,6 @@ const footerNav = {
   organization: [
     { label: "About", href: "/about" },
     { label: "GitHub", href: "https://github.com/noorinalabs" },
-    { label: "Contact Us", href: "mailto:info@noorinalabs.com" },
   ],
 };
 ---
@@ -105,11 +104,6 @@ const footerNav = {
         </ul>
       </div>
     </div>
-
-    <p class="footer-contact">
-      For inquiries, reach us at
-      <a href="mailto:info@noorinalabs.com">info@noorinalabs.com</a>
-    </p>
 
     <p class="footer-copyright">
       &copy; {new Date().getFullYear()} Noorina Labs. All rights reserved.
@@ -222,17 +216,9 @@ const footerNav = {
     outline-offset: 2px;
   }
 
-  .footer-contact {
-    max-width: 64rem;
-    margin: 0 auto 1rem;
-    font-family: var(--font-body);
-    font-size: 0.875rem;
-    color: var(--color-navy-300);
+  .footer-copyright {
     border-top: 1px solid var(--color-navy-700);
     padding-top: 1.5rem;
-  }
-
-  .footer-copyright {
     max-width: 64rem;
     margin: 0 auto;
     font-family: var(--font-body);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -371,10 +371,13 @@ import SEO from "../components/SEO.astro";
     font-size: 0.85rem;
     font-weight: 600;
     color: var(--color-gold-300);
-    padding: 0.35rem 1rem;
-    border: 1px solid var(--color-navy-500);
-    border-radius: 2rem;
     letter-spacing: 0.02em;
+  }
+
+  .hero-pillars .pillar:not(:last-child)::after {
+    content: "\00b7";
+    margin-left: 0.75rem;
+    color: var(--color-navy-400);
   }
 
   .hero-actions {


### PR DESCRIPTION
## Summary

- **#44 Broken links (LIVE BUG):** Fixed nginx `try_files` directive — was using SPA fallback (`/index.html`) which served the homepage for all routes instead of the correct static pages. Changed to `$uri/index.html =404` for proper Astro static site routing.
- **#45 Redundant email links:** Removed "Contact Us" mailto link from footer nav and "For inquiries" paragraph. The "Get in Touch" section on the homepage is the single email CTA.
- **#47 Hero pillar styling:** Removed border, padding, and border-radius from pillar spans so they read as plain text statements separated by middle dots, not clickable buttons.

Closes #44, Closes #45, Closes #47

## Test plan

- [x] `astro build` passes (3 pages generated)
- [x] `vitest run` passes (70/70 tests)
- [ ] Verify navigation works on deployed site: `/about`, `/projects/isnad-graph`, `/#projects`
- [ ] Verify footer has only one email reference (the "Get in Touch" section)
- [ ] Verify hero pillars appear as plain text, not buttons
- [ ] Verify back/forward browser navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)