### PR TITLE
ops: Audit .gitignore — add coverage, cache, and log patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,19 @@ playwright-report/
 
 # Vitest
 coverage/
+
+# Node.js
+npm-debug.log*
+yarn-debug.log*
+.eslintcache
+*.tsbuildinfo
+
+# Logs
+*.log
+
+# Cache
+.cache/
+
+# Temp
+tmp/
+temp/


### PR DESCRIPTION
## Summary
- Adds missing patterns: `npm-debug.log*`, `yarn-debug.log*`, `.eslintcache`, `*.tsbuildinfo`, `*.log`, `.cache/`, `tmp/`, `temp/`
- Existing Astro, Node, Playwright, and Vitest patterns were already in good shape
- No tracked files required removal

Closes #50

## Reviewer
Requestor (author): Santiago Ferreira
Requestee (reviewer): Aino Virtanen

## Test plan
- [ ] Verify new patterns appear in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)