### PR TITLE
ci(ghcr): emit sha-<short> + stg-<short> + stg-latest for same-SHA promotion (#68)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,9 +43,31 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tag scheme (isnad-graph#815 Contract v6 = option C, canonical at
+          # https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921):
+          #   sha-<short>   — immutable per-push; written here on every event
+          #   latest        — mutable pointer; written here on push to main
+          #   stg-<short>   — immutable per-push, stg namespace; written here
+          #                   ONLY on push to main. Tag history = stg deploy log.
+          #   stg-latest    — moving pointer to most-recent stg-<short>; written
+          #                   here ONLY on push to main.
+          #   prod-<short>  — immutable per-promotion, prod namespace; written
+          #                   by deploy#84 ONLY, NOT this file.
+          #   prod-latest   — moving pointer; written by deploy#84 ONLY.
+          # Tag-count invariants enforced by noorinalabs-deploy
+          # .github/workflows/image-tag-invariants.yml (four tags per push).
+          # NOTE: this job only runs via `workflow_run` from CI (constrained
+          # to `branches: [main]`) or `workflow_dispatch` from main. Both
+          # imply main, so the stg-* tags do not need an extra enable guard.
           tags: |
+            # Short SHA (e.g., sha-a1b2c3d) — IMMUTABLE anchor
+            type=sha,prefix=sha-,format=short
+            # Latest — mutable pointer
             type=raw,value=latest
-            type=sha,prefix=
+            # stg-<short> per-push in stg namespace — IMMUTABLE
+            type=sha,prefix=stg-,format=short
+            # stg-latest moving pointer
+            type=raw,value=stg-latest
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Closes #68

## Summary

Replicate the isnad-graph#815 image-tagging Contract (v6, option C) in `noorinalabs-landing-page`. On push to main, the build job now emits four tags that all point at the same built digest, enabling same-SHA stg→prod promotion without rebuild.

**Before** (`deploy.yml` meta-action):
- `latest`
- `<short-sha>` (no prefix)

**After**:
- `sha-<short>` — immutable per-push anchor
- `latest` — mutable pointer
- `stg-<short>` — immutable per-push, stg namespace
- `stg-latest` — moving pointer to the latest stg-`<short>`

`prod-<short>` + `prod-latest` are written exclusively by the deploy-side promotion workflow (deploy#84, Aisha's PR#155) via `docker buildx imagetools create` — registry-side retag, not a rebuild.

## Contract (consumer)

This PR consumes the image-tagging Contract owned by noorinalabs-isnad-graph#815.
Canonical source: https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921

Replicated shape (per push to main, four tags on same digest):
- `ghcr.io/noorinalabs/noorinalabs-landing-page:sha-<short>`
- `ghcr.io/noorinalabs/noorinalabs-landing-page:latest`
- `ghcr.io/noorinalabs/noorinalabs-landing-page:stg-<short>`
- `ghcr.io/noorinalabs/noorinalabs-landing-page:stg-latest`

Divergence from the owner Contract:
- Image name is `ghcr.io/noorinalabs/noorinalabs-landing-page` (vs isnad-graph api/frontend).
- Trigger model differs: landing-page's build-and-push job runs via `workflow_run` from CI (`branches: [main]`) or `workflow_dispatch`, so the `enable=` guards on stg-* tags are unnecessary here — both triggers already imply main. Contract shape is unchanged.
- No other divergence; tag suffix convention matches exactly.
- `prod-<short>` + `prod-latest` are written exclusively by deploy#84 (Aisha's promotion workflow, not this PR).

## Breaking change note

The previous unprefixed `:<short>` tag is replaced by `:sha-<short>`. Searched for consumers:
- `noorinalabs-deploy/compose/docker-compose.prod.yml` pins via `${LANDING_IMAGE_TAG:-latest}` — unaffected.
- No other ref to `ghcr.io/noorinalabs/noorinalabs-landing-page:<short>` anywhere in the org.

## Invariant coverage

`noorinalabs-deploy/.github/workflows/image-tag-invariants.yml` already includes `noorinalabs/noorinalabs-landing-page` in its matrix (line 59). That probe asserts exactly four tags per push point at the built digest — this PR brings the image into compliance.

## Test plan

- [x] Local YAML lint — workflow parses
- [ ] Push to branch → CI green (draft PR, still running)
- [ ] After merge to main: verify GHCR shows four tags (`sha-<short>`, `latest`, `stg-<short>`, `stg-latest`) on the same digest
- [ ] Observe `noorinalabs-deploy` tag-invariant probe green on next scheduled run

## Out of scope

- Landing-page content / Astro pages / design-system consumption — unrelated.
- Deploy-side promotion workflow (`prod-*` tags) — owned by deploy#84 (Aisha).
- Adding a tag-count invariant probe in this repo — already covered org-side in deploy#84.

---

Target branch: `deployments/phase-2/wave-10`
Reviewers: Cédric Novák (primary, UX/Visual Designer) + cross-team CI reviewer (TBD — likely Linh Pham per Contract ownership)
