### PR TITLE
chore(hooks): register validate_pr_ci_status (Hook 14) — sync from parent (#194)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_ci_status.py",
+            "timeout": 15
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Registers `validate_pr_ci_status.py` (Hook 14) in this repo's `.claude/settings.json` so that `gh pr merge` invocations against landing-page PRs are gated on green CI, matching the parent `noorinalabs-main` enforcement.

This is the **proof-of-pattern PR** for org-wide Hook 14 sync (parent issue: noorinalabs/noorinalabs-main#194). Symlink-style child repos (this one, `noorinalabs-data-acquisition`, `noorinalabs-design-system`) get a 1-line `settings.json` change pointing at the parent's hook file. Copy-resident repos will follow with their own pattern.

## Why this PR is small

The hook .py file already lives at `noorinalabs-main/.claude/hooks/validate_pr_ci_status.py`. This repo's `settings.json` registers shared hooks via parent-canonical absolute paths (the symlink-style pattern). So this PR is a single new entry in the existing `PreToolUse > Bash` matcher list — no file copies needed, no annunaki_log.py dependency to vendor.

## Architectural context (informational, not in scope)

The two-pattern split (symlink-style vs copy-resident) across child repos is captured in noorinalabs/noorinalabs-main#214 (rationalize to one pattern) and #215 (two child repos lack settings.json entirely). Those follow-ups are tracked for p2-wave-11; this PR ships the gate now to close the immediate red-CI-merge hole.

## Verification

- `python3 -c "import json; json.load(open('.claude/settings.json'))"` — well-formed
- `Bash` matcher entries: 5 → 6 (Hook 14 appended last per the dispatcher's ordering convention)
- Hook 14's behavior is unchanged — same script as the parent runs

## Test plan

- [ ] Reviewer 1 inspects the diff — single matcher entry added at end of Bash hook list
- [ ] Reviewer 2 confirms the parent path `noorinalabs-main/.claude/hooks/validate_pr_ci_status.py` exists and is the canonical Hook 14
- [ ] After merge: open a test PR with a deliberately failing check, confirm `gh pr merge` blocks with the Hook 14 reason text
- [ ] After merge: monitor next 5 child PRs to confirm Hook 14 fires on `gh pr merge` invocations

## Refs

- Parent issue: noorinalabs/noorinalabs-main#194
- Followup #214 (rationalization to single hook-registration pattern, p2-wave-11)
- Followup #215 (two child repos missing settings.json, p2-wave-11)
- Followup #216 (block_git_config substring-bug surfaced during this work, p2-wave-11)
- Charter: `noorinalabs-main/.claude/team/charter/hooks.md` § Hook 14
- P2W9 retro entry that spawned the parent issue: `feedback_log.md` 2026-04-22
