### PR TITLE
fix(landing-page #77): Deploy-to-VPS workflow regression

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,17 @@
-name: Deploy
+name: Publish to GHCR
+
+# Publishes landing-page container images to GHCR on push to main.
+#
+# Production rollout flows through the deploy repo:
+#   noorinalabs-deploy/.github/workflows/promote.yml   (registry retag stg-* → prod-*)
+#   noorinalabs-deploy/.github/workflows/deploy-prod.yml (SSH deploy to prod VPS)
+#
+# This workflow does NOT push-time SSH-deploy (intentional architectural
+# divergence from isnad-graph/user-service per ontology
+# `repos/landing-page.yaml § ci.deploy_workflow.description`). The previous
+# `deploy` job here was a leftover from the original (a32a249) one-VPS
+# topology and was removed in #77 after it began timing out against
+# vars.VPS_HOST in the W10 stg/prod split (deploy#86 / main#212).
 
 on:
   workflow_run:
@@ -8,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-production
+  group: publish-${{ github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -95,50 +108,14 @@ jobs:
           secrets: |
             npm_token=${{ secrets.GH_PACKAGES_TOKEN }}
 
-  deploy:
-    name: Deploy to VPS
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    timeout-minutes: 10
-    environment: production
-
-    steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
-        env:
-          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
-        with:
-          host: ${{ vars.VPS_HOST }}
-          username: deploy
-          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: GH_PACKAGES_TOKEN
-          script: |
-            set -euo pipefail
-            cd /opt/noorinalabs-deploy
-            git fetch origin main && git reset --hard origin/main
-
-            echo "$GH_PACKAGES_TOKEN" | docker login ghcr.io -u noorinalabs --password-stdin
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env pull landing
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env up -d landing
-            docker compose -p noorinalabs -f compose/docker-compose.prod.yml --env-file .env restart caddy
-
-            echo "==> Waiting for landing service to stabilize..."
-            for i in $(seq 1 12); do
-              health=$(docker inspect --format='{{.State.Health.Status}}' noorinalabs-landing-1 2>/dev/null || echo "not_found")
-              echo "Attempt $i/12: landing=$health"
-              if [ "$health" = "healthy" ]; then echo "Landing page healthy"; break; fi
-              if [ "$i" -eq 12 ]; then
-                echo "ERROR: Landing health check failed after 60 seconds"
-                docker compose -p noorinalabs -f compose/docker-compose.prod.yml logs --tail=50 landing
-                exit 1
-              fi
-              sleep 5
-            done
-
-      - name: Report deployment status
+      - name: Report publish status
         if: always()
         run: |
-          echo "## Deploy noorinalabs-landing-page: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Image:** ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Publish to GHCR: ${{ job.status }}"
+            echo ""
+            echo "- **Image:** ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+            echo "- **Triggered by:** ${{ github.actor }}"
+            echo ""
+            echo "Production rollout: triggered separately via \`noorinalabs-deploy/.github/workflows/promote.yml\`."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #77

## Summary

Hotfix for the `Deploy` workflow on `noorinalabs-landing-page` main, red since
2026-05-04. The fix is to **delete the redundant push-time SSH-deploy job**
and rename the workflow to reflect what it actually does (publish images).

### Root cause

The repo-resident `.github/workflows/deploy.yml` had a `deploy` job using
`appleboy/ssh-action@v1` that SSH'd into `vars.VPS_HOST` (87.99.134.161) on
every push to main. As of the W10 stg/prod VPS split (`deploy#86` /
`main#212`), connections to that IP from GitHub-Actions runners now time out:

- First failure: run [25298301491](https://github.com/noorinalabs/noorinalabs-landing-page/actions/runs/25298301491) (2026-05-04T02:37:03Z) — `2026/05/04 02:38:33 dial tcp 87.99.134.161:22: i/o timeout`
- Latest failure: run [25410410336](https://github.com/noorinalabs/noorinalabs-landing-page/actions/runs/25410410336) (2026-05-06T00:46:19Z) — same `i/o timeout` mode

`Build & Push` succeeded in both runs; the failure is isolated to the SSH-deploy step.

### Why the job was redundant

Per ontology `noorinalabs-main/ontology/repos/landing-page.yaml § ci.deploy_workflow.description`:

> "No notify-deploy step — landing-page deploy flows through deploy/promote.yml registry retag, not push-time dispatch (intentional architectural divergence from isnad-graph/user-service per Cédric's review note)."

The canonical prod rollout path is:

1. `noorinalabs-deploy/.github/workflows/promote.yml` — retags `stg-<short>` → `prod-<short>` (Image-tag Contract v6 `option C`)
2. `noorinalabs-deploy/.github/workflows/deploy-prod.yml` — SSH-deploys to prod VPS (handles `landing` alongside `api` / `frontend` / `user-service`, see L80–87, 169, 229)

The `deploy` job in this workflow was a leftover from the pre-W10 one-VPS topology (commit `a32a249`, "Replace placeholder deploy workflow with GHCR build/push and VPS SSH deploy"). Documentation already said it shouldn't exist; the W10 split made the inconsistency operationally visible. The deploy repo's sibling `deploy-landing-page.yml` is also marked `LEGACY — manual only` and confirms `landing-page prod rollout flows via promote.yml → deploy-prod.yml`.

### Operational impact

None during the regression window — `Build & Push` was succeeding every time, so `promote.yml` could (and presumably did) consume the images. The red workflow status was cosmetic.

### Changes

- `.github/workflows/deploy.yml`:
  - `name: Deploy` → `name: Publish to GHCR`
  - `concurrency.group: deploy-production` → `publish-${{ github.ref_name }}` (matches sibling pattern in `noorinalabs-isnad-graph/.github/workflows/ghcr-publish.yml`)
  - Header comment added pointing readers to `promote.yml` / `deploy-prod.yml` for prod rollout
  - `deploy` job deleted (45 lines)
  - `Report deployment status` → `Report publish status` step folded into `build-and-push`

`Build & Push` step list, image tags (Contract v6: `sha-<short>`, `latest`, `stg-<short>`, `stg-latest`), buildx + provenance OCI image-index emission (deploy#242) — all unchanged.

## Test Plan

- [ ] PR review by R1 (Lucas Ferreira, deploy roster — workflow expertise) and R2 (Marcia Vasquez-Paredes, landing-page roster)
- [ ] `actionlint .github/workflows/deploy.yml` clean (verified locally with shellcheck 0.10.0 + actionlint 1.7.7 per `feedback_actionlint_needs_shellcheck.md`)
- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` — verified locally)
- [ ] Wave-6 base merges; on next push to main after wave-6 → main, the workflow run on main posts `Publish to GHCR` (was `Deploy`) and shows only the `Build & Push Docker Image` job, green
- [ ] `noorinalabs-deploy/.github/workflows/promote.yml` next dispatch still successfully retags landing's `stg-<short>` → `prod-<short>` (no functional change here, just confirming the canonical path still works)
- [ ] Post-merge runtime check (NOT PR acceptance per `feedback_pr_vs_runtime_acceptance_criteria.md` and `feedback_runtime_gate_scoping.md`): Deploy/Publish-to-GHCR workflow green on main; production landing-page reachable at https://noorinalabs.com after next promote.yml dispatch.

### Out of scope (deliberately deferred)

- The underlying `vars.VPS_HOST` connectivity question (why SSH from GitHub Actions runners to 87.99.134.161:22 now times out) is unrelated to landing-page's CI/CD path and is tracked as part of `main#212` (two-VPS topology / W10 stg/prod split) and `deploy#86` (VPS decommission sequencing).
- Renaming the file `.github/workflows/deploy.yml` → `publish.yml` is left out to preserve the historical run-history thread accessible at the existing URLs. The internal `name:` is updated for clarity.
