### PR TITLE
chore(hooks): align settings.json matchers with parent canonical (#85)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,58 +6,199 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_commit_identity.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_no_verify.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_git_config.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_set_env_test.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_labels.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/dispatcher.py",
             "timeout": 30
           }
         ]
       },
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_context.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_ontology_context.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "SendMessage",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_shutdown_without_retro.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_audit.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_ci_status.py",
-            "timeout": 15
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_add_issue_to_board.py",
+            "timeout": 20
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/annunaki_monitor.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_handoff.py",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
## Summary

Aligns `noorinalabs-landing-page/.claude/settings.json` with the parent
canonical at `noorinalabs-main/.claude/settings.json`. After this change
the two files are **byte-exact identical** when serialized through
`json.dumps(..., sort_keys=True, indent=2)` — verified locally.

Closes the matcher-coverage gap surfaced by issue #85: sessions opened
directly in this repo (not via the parent orchestrator) previously
silently skipped Hook 15 (`enforce_librarian_consulted`),
`ontology_tracker.py`, session handoff, agent/skill/sendmessage gates,
and several others.

## What changed

| Surface | Before | After |
|---|---|---|
| `PreToolUse` Bash | 6 individual entries | single `dispatcher.py` (same 6 hooks consolidated) |
| `PreToolUse` Agent | (missing) | `validate_wave_context`, `enforce_ontology_context` |
| `PreToolUse` SendMessage | (missing) | `block_shutdown_without_retro`, `validate_edit_completion` |
| `PreToolUse` Skill | (missing) | `validate_wave_audit` |
| `PreToolUse` Edit/Write/NotebookEdit | (missing) | `enforce_librarian_consulted`, `validate_edit_completion` |
| `PostToolUse` Bash | (missing) | `auto_add_issue_to_board`, `annunaki_monitor` |
| `PostToolUse` Edit/Write | (missing) | `ontology_tracker`, `suggest_generic_prompt`, `validate_edit_completion` |
| `PostToolUse` NotebookEdit | (missing) | `validate_edit_completion` |
| `SessionStart` startup/resume | (missing) | `session_start.py` |
| `Stop` | (missing) | `session_handoff.py` |

All hook script paths point at the parent canonical
(`noorinalabs-main/.claude/hooks/<file>.py`) — no copy-resident hook
bodies are added, so dispatcher-style status (parent#311 sub-clause)
is preserved.

## Why dispatcher consolidation for Bash

The previous 6 individual entries listed exactly the hooks that
`noorinalabs-main/.claude/hooks/dispatcher.py` runs internally
(verified by grep: `validate_commit_identity`, `block_no_verify`,
`block_git_config`, `auto_set_env_test`, `validate_labels`,
`validate_pr_ci_status`). Replacing them with a single dispatcher
call:

- gives byte-exact parity with the parent settings.json
- centralizes future hook additions (parent dispatcher updates flow
  through automatically rather than requiring per-child settings.json
  edits)
- matches the dispatcher-style pattern named in main#311

## Verification

```bash
$ python3 -c "import json; json.load(open('.claude/settings.json'))" \
  && echo "JSON valid"
JSON valid

$ diff \
  <(python3 -c "import json; print(json.dumps(json.load(open('../noorinalabs-main/.claude/settings.json')),indent=2,sort_keys=True))") \
  <(python3 -c "import json; print(json.dumps(json.load(open('.claude/settings.json')),indent=2,sort_keys=True))") \
  && echo "MATCHES PARENT EXACTLY"
MATCHES PARENT EXACTLY
```

## Cross-links

- Closes #85
- Predecessor (P3W5 dispatcher migration): #78, PR #79
- Audit meta-issue (P3W7): `noorinalabs/noorinalabs-main#300`
- Charter sub-clause (P3W8): `noorinalabs/noorinalabs-main#311`

## Reviewers

Requestor: Kofi Mensah-Williams
Requestee: Nazia Rahman (R1) + Marcia Vasquez-Paredes (R2)

## Acceptance

- [x] settings.json reload-clean (`json.load` succeeds)
- [x] Byte-exact match with parent canonical
- [x] Hook script paths absolute, point at parent canonical
- [ ] CI green
- [ ] Two reviewer approvals with `TechDebt:` line

## Test Plan

- [x] Local JSON validity confirmed
- [x] Byte-exact diff against parent confirmed (`MATCHES PARENT EXACTLY`)
- [ ] Reviewer to confirm Claude Code can load settings.json without parse error
- [ ] Reviewer to spot-check that `/ontology-librarian` invocation in a fresh session opened directly in this repo successfully writes the Hook 15 sentinel (verifies the Edit/Write matcher pipeline)
