### PR TITLE
ci(actions): upgrade Node 20 actions to current majors (#88, parent#309)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -87,7 +87,7 @@ jobs:
         run: npx playwright test --project=desktop-chromium
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # buildx + provenance=true wraps the manifest in an OCI image index
       # (mediaType: application/vnd.oci.image.index.v1+json) even for a


### PR DESCRIPTION
## Summary

Upgrades 6 GitHub Actions call sites away from Node-20 deprecated
majors, matching the `noorinalabs-isnad-graph` reference state from the
parent#309 audit table.

| File | Line | Action | v4-era | Target |
|------|------|--------|--------|--------|
| `.github/workflows/ci.yml` | 24 | `actions/checkout` | `@v4` | `@v6` |
| `.github/workflows/ci.yml` | 27 | `actions/setup-node` | `@v4` | `@v6` |
| `.github/workflows/ci.yml` | 65 | `actions/checkout` | `@v4` | `@v6` |
| `.github/workflows/ci.yml` | 68 | `actions/setup-node` | `@v4` | `@v6` |
| `.github/workflows/ci.yml` | 90 | `actions/upload-artifact` | `@v4` | `@v7` |
| `.github/workflows/deploy.yml` | 45 | `actions/checkout` | `@v4` | `@v6` |

Six diff lines, two files, no other changes.

## upload-artifact v5+ name-uniqueness check

`actions/upload-artifact` v5+ enforces per-job artifact name uniqueness
at runtime: two `upload-artifact` steps that share a `name:` value
within the same workflow run will fail at the second upload.

**This repo is not at risk.** Verified by grep on the head SHA
(`gh api repos/noorinalabs/noorinalabs-landing-page/contents/.github/workflows/ci.yml?ref=<head>`):

- One single call site, `ci.yml:90`, in the `e2e` job
- `name: playwright-report`
- `if: ${{ !cancelled() }}` branch (uploads even on test failure, but
  not on cancel)
- No other job in either workflow uses `upload-artifact`

So the v7 bump is mechanically safe — the only failure mode the version
change introduces (name collision) cannot occur in this workflow shape.

## Verification

```bash
$ grep -nE "actions/(checkout|setup-node|upload-artifact)@" \
    .github/workflows/ci.yml .github/workflows/deploy.yml
.github/workflows/ci.yml:24:        uses: actions/checkout@v6
.github/workflows/ci.yml:27:        uses: actions/setup-node@v6
.github/workflows/ci.yml:65:        uses: actions/checkout@v6
.github/workflows/ci.yml:68:        uses: actions/setup-node@v6
.github/workflows/ci.yml:90:        uses: actions/upload-artifact@v7
.github/workflows/deploy.yml:45:        uses: actions/checkout@v6

$ grep -nE "@v4" .github/workflows/*.yml
(no output — clean)

$ actionlint .github/workflows/ci.yml .github/workflows/deploy.yml
(no output, rc=0 — clean with shellcheck on PATH)
```

## Cross-links

- Closes #88
- Parent meta-issue: `noorinalabs/noorinalabs-main#309`
- Reference state (target versions): `noorinalabs/noorinalabs-isnad-graph`

## Reviewers

Requestor: Kofi Mensah-Williams
Requestee: Nazia Rahman (R1) + Marcia Vasquez-Paredes (R2)

## Acceptance

- [x] All 6 sites at target versions (post-edit grep matches table)
- [x] No `@v4` remnants
- [x] actionlint clean (shellcheck installed first per `feedback_actionlint_needs_shellcheck.md`)
- [x] upload-artifact name-uniqueness verified non-applicable (single
      call site, single job context)
- [ ] CI green including the playwright e2e path that exercises
      `upload-artifact@v7`
- [ ] Two reviewer approvals with `TechDebt:` line

## Test Plan

- [x] Local actionlint pass on both files
- [x] Diff stat: 2 files, 6 +/-, no collateral
- [ ] Reviewer to confirm CI run uploads `playwright-report` artifact
      successfully under `upload-artifact@v7`
- [ ] Reviewer to confirm no Node 20 deprecation warning in the GitHub
      Actions run summary post-merge
