### PR TITLE
fix(a11y): resolve dangling aria-labelledby + remove redundant role="link" (#61)

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -57,7 +57,7 @@ const {
 
     {
       cta && (
-        <a href={cta.href} class="cta-button" role="link">
+        <a href={cta.href} class="cta-button">
           {cta.label}
         </a>
       )

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,6 +40,7 @@ import SEO from "../components/SEO.astro";
   <!-- Guiding Principle -->
   <section class="section" aria-labelledby="principle-heading">
     <div class="section-container principle-container">
+      <h2 id="principle-heading" class="sr-only">Guiding Principle</h2>
       <blockquote class="principle-quote">
         <p>
           Noorina Labs will never privilege one school of thought, one


### PR DESCRIPTION
## Summary

Two WCAG 2.2 AA accessibility fixes for landing-page#61:

1. **`src/pages/index.astro`** — the Guiding Principle `<section>` used `aria-labelledby="principle-heading"` but no element with that `id` existed in the page. Screen readers would fail to announce the section. Added a visually-hidden `<h2 id="principle-heading" class="sr-only">Guiding Principle</h2>` so the `aria-labelledby` reference resolves to real text content.
2. **`src/layouts/ProjectLayout.astro`** — the CTA `<a>` carried an explicit `role="link"` on top of the anchor's implicit link role. Redundant ARIA can interfere with assistive tech (Axe rule family: `aria-allowed-attr` / `no-redundant-roles`, WCAG 4.1.2). Removed the attribute; the `<a>` already exposes the link role.

## Why `sr-only`

Tailwind v4 (this repo's bundler) emits `sr-only` as a default utility. Verified the compiled CSS contains the canonical rule (`clip-path: inset(50%)` etc.) — see `dist/_astro/*.css` after `npm run build`.

## Acceptance

- `npm run build` — clean. Rendered HTML inspected:
  - `dist/index.html` contains `aria-labelledby="principle-heading"` AND `<h2 id="principle-heading" class="sr-only">Guiding Principle</h2>` inside the same `<section>`.
  - `dist/index.html`, `dist/about/index.html`, `dist/projects/isnad-graph/index.html` all contain zero `role="link"` occurrences.
- `npm test` — 70/70 unit tests pass.
- `npm run test:e2e -- --project=desktop-chromium` — **19/19 pass**, including all 3 Axe WCAG 2a/2aa checks on `/`, `/about`, `/projects/isnad-graph`.
- `npx prettier --check` on touched files — clean. `npm run lint` only flagged pre-existing untouched files (`.claude/scratch/0088-pr-body.md`, `.claude/scratch/85-pr-body.md`, `RUNBOOK.md`).

## Reviewer slate (per spawn brief)

- **R1**: Anika Diop-Sarr (Content Strategist, landing-page)
- **R2**: Kofi Mensah-Williams (Frontend Engineer, landing-page)

Manager-boundary verified: Marcia Vasquez-Paredes (landing-page lead) NOT on slate.

## Test plan

- [ ] Reviewer: confirm rendered DOM shows `<h2 id="principle-heading">` inside the `aria-labelledby="principle-heading"` section.
- [ ] Reviewer: confirm `role="link"` is no longer present in `ProjectLayout.astro` CTA anchor.
- [ ] CI: Axe e2e job stays green.

Closes #61.
