### PR TITLE
tech-debt(css): dedupe button/grid CSS (#59)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,28 +112,28 @@ import SEO from "../components/SEO.astro";
         questions that existing tools cannot.
       </p>
       <div class="capabilities-grid">
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Cross-Collection Search</h3>
           <p>
             Search narrators and hadith across major Sunni and Shia collections
             simultaneously — no more switching between siloed databases.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Graph Explorer</h3>
           <p>
             Visualize narrator networks as an interactive graph. Zoom, filter,
             and trace transmission paths between any two narrators.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Cross-Tradition Comparison</h3>
           <p>
             Compare narrator assessments across Sunni and Shia traditions
             side-by-side. Discover shared narrators and divergent evaluations.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Historical Context</h3>
           <p>
             Biographical profiles with teacher-student relationships,
@@ -141,7 +141,7 @@ import SEO from "../components/SEO.astro";
             rijal literature.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Collection-Level Analysis</h3>
           <p>
             Understand the structure of individual hadith collections — most
@@ -162,7 +162,7 @@ import SEO from "../components/SEO.astro";
     <div class="section-container">
       <h2 id="why-now-heading" class="section-title">Why Now</h2>
       <div class="why-now-grid">
-        <div class="why-now-card">
+        <div class="card card-center">
           <h3>Computational tools have matured</h3>
           <p>
             Graph databases, network analysis, and natural language processing
@@ -170,7 +170,7 @@ import SEO from "../components/SEO.astro";
             replace — hadith scholarship.
           </p>
         </div>
-        <div class="why-now-card">
+        <div class="card card-center">
           <h3>Open data is available</h3>
           <p>
             Digitized hadith collections and biographical dictionaries are now
@@ -178,7 +178,7 @@ import SEO from "../components/SEO.astro";
             possible for the first time.
           </p>
         </div>
-        <div class="why-now-card">
+        <div class="card card-center">
           <h3>Institutional appetite is growing</h3>
           <p>
             Universities, research centers, and Islamic institutions are
@@ -202,7 +202,7 @@ import SEO from "../components/SEO.astro";
         funders who share our commitment to open, rigorous, and inclusive tools.
       </p>
       <div class="partnership-grid">
-        <div class="partnership-card">
+        <div class="card card-surface">
           <h3>Research Partnership</h3>
           <p>
             Collaborate on data curation, scholarly review, and new analytical
@@ -210,7 +210,7 @@ import SEO from "../components/SEO.astro";
             meets the standards of the tradition.
           </p>
         </div>
-        <div class="partnership-card">
+        <div class="card card-surface">
           <h3>Institutional License</h3>
           <p>
             Integrate the Isnad Graph into your university or research center.
@@ -218,7 +218,7 @@ import SEO from "../components/SEO.astro";
             available for academic institutions.
           </p>
         </div>
-        <div class="partnership-card">
+        <div class="card card-surface">
           <h3>Grant & Philanthropic</h3>
           <p>
             Support open-source infrastructure for Islamic scholarship. Grants
@@ -388,98 +388,9 @@ import SEO from "../components/SEO.astro";
     justify-content: center;
   }
 
-  /* Buttons */
-  .btn-primary {
-    display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background: var(--color-gold-500);
-    color: var(--color-navy-950);
-    font-family: var(--font-body);
-    font-weight: 600;
-    font-size: 0.95rem;
-    border-radius: 0.375rem;
-    text-decoration: none;
-    transition:
-      background-color 0.2s ease,
-      transform 0.15s ease;
-  }
-
-  .btn-primary:hover {
-    background: var(--color-gold-400);
-  }
-
-  .btn-primary:focus-visible {
-    outline: 2px solid var(--color-gold-300);
-    outline-offset: 2px;
-  }
-
-  .btn-primary:active {
-    transform: scale(0.98);
-  }
-
-  .btn-secondary {
-    display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background: transparent;
-    color: var(--color-neutral-100);
-    font-family: var(--font-body);
-    font-weight: 600;
-    font-size: 0.95rem;
-    border: 1.5px solid var(--color-navy-300);
-    border-radius: 0.375rem;
-    text-decoration: none;
-    transition:
-      border-color 0.2s ease,
-      color 0.2s ease;
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-gold-400);
-    color: var(--color-gold-300);
-  }
-
-  .btn-secondary:focus-visible {
-    outline: 2px solid var(--color-gold-300);
-    outline-offset: 2px;
-  }
-
-  /* Sections */
-  .section {
-    padding: 5rem 1.5rem;
-  }
-
-  .section-alt {
-    background: var(--color-neutral-50);
-  }
-
-  .section-container {
-    max-width: 64rem;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-size: clamp(1.5rem, 3vw, 2.25rem);
-    font-weight: 700;
-    color: var(--color-navy-800);
-    text-align: center;
-    margin-bottom: 3rem;
-  }
-
-  .section-intro {
-    font-family: var(--font-body);
-    font-size: 1.05rem;
-    line-height: 1.8;
-    color: var(--color-neutral-700);
-    text-align: center;
-    max-width: 48rem;
-    margin: 0 auto 2.5rem;
-  }
-
-  .section-cta {
-    text-align: center;
-    margin-top: 2.5rem;
-  }
+  /* Buttons, section helpers, and shared card primitives are defined globally
+     in src/styles/global.css (extracted in #59). Hero/principle/grid styles
+     and one-off page-specific styles remain scoped below. */
 
   /* Guiding Principle */
   .principle-container {
@@ -564,29 +475,8 @@ import SEO from "../components/SEO.astro";
     }
   }
 
-  .capability-card {
-    padding: 2rem;
-    background: var(--color-neutral-50);
-    border-radius: 0.75rem;
-    border: 1px solid var(--color-neutral-200);
-  }
-
-  .capability-card h3 {
-    font-family: var(--font-heading);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-navy-800);
-    margin-bottom: 0.75rem;
-  }
-
-  .capability-card p {
-    font-family: var(--font-body);
-    font-size: 0.925rem;
-    line-height: 1.7;
-    color: var(--color-neutral-600);
-  }
-
-  /* Why Now Grid */
+  /* Why Now Grid — distinct breakpoint/gap from capabilities; card visuals
+     come from .card.card-center in global.css */
   .why-now-grid {
     display: grid;
     gap: 2rem;
@@ -599,27 +489,8 @@ import SEO from "../components/SEO.astro";
     }
   }
 
-  .why-now-card {
-    text-align: center;
-    padding: 2rem 1.5rem;
-  }
-
-  .why-now-card h3 {
-    font-family: var(--font-heading);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-navy-800);
-    margin-bottom: 0.75rem;
-  }
-
-  .why-now-card p {
-    font-family: var(--font-body);
-    font-size: 0.925rem;
-    line-height: 1.7;
-    color: var(--color-neutral-600);
-  }
-
-  /* Partnership Grid */
+  /* Partnership Grid — same shape as why-now but card visuals come from
+     .card.card-surface in global.css */
   .partnership-grid {
     display: grid;
     gap: 2rem;
@@ -632,38 +503,8 @@ import SEO from "../components/SEO.astro";
     }
   }
 
-  .partnership-card {
-    padding: 2rem;
-    background: var(--color-neutral-50);
-    border-radius: 0.75rem;
-    border: 1px solid var(--color-neutral-200);
-  }
-
-  .partnership-card h3 {
-    font-family: var(--font-heading);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-navy-800);
-    margin-bottom: 0.75rem;
-  }
-
-  .partnership-card p {
-    font-family: var(--font-body);
-    font-size: 0.925rem;
-    line-height: 1.7;
-    color: var(--color-neutral-600);
-  }
-
   /* Contact */
   .contact-container {
     text-align: center;
-  }
-
-  /* Reduced motion */
-  @media (prefers-reduced-motion: reduce) {
-    .btn-primary,
-    .btn-secondary {
-      transition: none;
-    }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,3 +130,137 @@
     --color-text: var(--color-foreground);
   }
 }
+
+/*
+ * Shared primitives (#59)
+ * -----------------------
+ * Buttons, section helpers, and card typography extracted from
+ * src/pages/index.astro. These are page-agnostic — visual concerns live here;
+ * page-specific layout (hero, principle-container, contact-container, the
+ * three grid breakpoint specs) stays scoped to the consuming page.
+ *
+ * Card typography (.card h3, .card p) is shared across capability cards,
+ * why-now cards, and partnership cards; surface and alignment variants are
+ * applied via .card-surface and .card-center modifiers.
+ */
+
+/* Buttons */
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: var(--color-gold-500);
+  color: var(--color-navy-950);
+  transition:
+    background-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.btn-primary:hover {
+  background: var(--color-gold-400);
+}
+
+.btn-primary:active {
+  transform: scale(0.98);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--color-neutral-100);
+  border: 1.5px solid var(--color-navy-300);
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.btn-secondary:hover {
+  border-color: var(--color-gold-400);
+  color: var(--color-gold-300);
+}
+
+.btn-primary:focus-visible,
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--color-gold-300);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-primary,
+  .btn-secondary {
+    transition: none;
+  }
+}
+
+/* Section helpers */
+.section {
+  padding: 5rem 1.5rem;
+}
+
+.section-alt {
+  background: var(--color-neutral-50);
+}
+
+.section-container {
+  max-width: 64rem;
+  margin: 0 auto;
+}
+
+.section-title {
+  font-family: var(--font-heading);
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  font-weight: 700;
+  color: var(--color-navy-800);
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-intro {
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--color-neutral-700);
+  text-align: center;
+  max-width: 48rem;
+  margin: 0 auto 2.5rem;
+}
+
+.section-cta {
+  text-align: center;
+  margin-top: 2.5rem;
+}
+
+/* Card primitives — shared typography across capability/why-now/partnership */
+.card h3 {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-navy-800);
+  margin-bottom: 0.75rem;
+}
+
+.card p {
+  font-family: var(--font-body);
+  font-size: 0.925rem;
+  line-height: 1.7;
+  color: var(--color-neutral-600);
+}
+
+.card-surface {
+  padding: 2rem;
+  background: var(--color-neutral-50);
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-neutral-200);
+}
+
+.card-center {
+  text-align: center;
+  padding: 2rem 1.5rem;
+}

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -21,13 +21,17 @@ test.describe("Responsive behavior", () => {
 
   test("capability cards are rendered", async ({ page }) => {
     await page.goto("/");
-    const cards = page.locator(".capability-card");
+    const cards = page.locator(
+      'section[aria-labelledby="capabilities-heading"] .card-surface',
+    );
     await expect(cards).toHaveCount(5);
   });
 
   test("partnership cards are rendered", async ({ page }) => {
     await page.goto("/");
-    const cards = page.locator(".partnership-card");
+    const cards = page.locator(
+      'section[aria-labelledby="partnership-heading"] .card-surface',
+    );
     await expect(cards).toHaveCount(3);
   });
 });


### PR DESCRIPTION
## Summary

Closes #59. Extracts duplicated CSS out of `src/pages/index.astro` and into `src/styles/global.css` so it becomes reusable across the site instead of one-page chrome:

- **Buttons** (`.btn-primary`, `.btn-secondary`) — shared properties (display/padding/font/border-radius/text-decoration) collapsed into a single comma rule; shared `:focus-visible` outline and shared `(prefers-reduced-motion)` transition opt-out also merged. Hover/active state rules preserved as-is.
- **Section helpers** — `.section`, `.section-alt`, `.section-container`, `.section-title`, `.section-intro`, `.section-cta` lifted as page-agnostic primitives so future pages can adopt the LP's section rhythm without duplicating these blocks.
- **Card primitives** — introduces `.card` (shared h3/p typography), `.card-surface` (padding + neutral-50 bg + border modifier), and `.card-center` (centered text + tighter padding modifier). The three near-identical card classes in `index.astro` — `capability-card`, `partnership-card`, `why-now-card` — collapse to `card card-surface` / `card card-center` at the markup site.

The three grid container classes (`.capabilities-grid`, `.why-now-grid`, `.partnership-grid`) stay scoped to `index.astro` because their breakpoint/gap specs differ (capabilities: 1→2 @640→3 @1024, gap 1.5rem; why-now and partnership: 1→3 @768, gap 2rem). Deduplicating those would be a forced abstraction.

## Net impact

| File | Before | After | Δ |
|---|---:|---:|---:|
| `src/pages/index.astro` | 668 | 510 | -158 |
| `src/styles/global.css` | 132 | 266 | +134 |

177 lines moved out of `index.astro`; 134 lines reintroduced in `global.css` as shared primitives. The asymmetry comes from de-duplication — three card declarations collapsed into one `.card` rule plus two small modifiers, and shared button properties (display/padding/font/etc.) factored out of two long rules into one comma-rule.

## Visual / behavioural delta

None expected vs `origin/deployments/phase-3/wave-10` head `e8cc7fb`. Same selectors, same property values — just relocated and de-duplicated. All references to `.btn-primary`/`.btn-secondary`/`.section-*` continue to work because they're now defined globally (loaded via `BaseLayout` → `global.css`) instead of in the scoped `<style>` block.

## Verification

- `npm run build` — clean, 4 pages built, no warnings.
- `dist/_astro/PageLayout.*.css` confirmed to contain `.btn-primary`, `.btn-secondary`, `.section-container`, `.section-title`, `.section-intro`, `.section-cta`, `.card`, `.card-surface`, `.card-center`.
- `dist/index.html` rendered HTML uses `class="card card-surface"` / `class="card card-center"` at every former card site (5 capability + 3 why-now + 3 partnership = 11 occurrences).
- `npm run lint` — no new findings (one pre-existing prettier warn on `RUNBOOK.md` is unrelated).

## Out of scope

- Migrating buttons/sections/cards to be DS components (would be `@noorinalabs/design-system` work, not LP-internal refactor) — appropriate follow-up if the team wants to push these primitives upstream once the DS publish pipeline is healthy.
- Touching `PageLayout.astro` / `BaseLayout.astro` scoped styles — they don't consume the duplicated classes, so no leverage from extracting them in this PR.
