### PR TITLE
fix(landing-page #62): SEO fallback URL + draft filter

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -18,7 +18,7 @@ interface Props {
 const { schemas = [] } = Astro.props;
 
 const siteUrl =
-  Astro.site?.toString().replace(/\/$/, "") ?? "https://noorinalabs.org";
+  Astro.site?.toString().replace(/\/$/, "") ?? "https://www.noorinalabs.com";
 
 const organizationSchema = {
   "@context": "https://schema.org",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,6 +10,7 @@ import PageLayout from "../layouts/PageLayout.astro";
 
 const entry = await getEntry("pages", "about");
 if (!entry) throw new Error("Missing content entry: pages/about");
+if (entry.data.draft) return Astro.redirect("/404");
 
 const { Content } = await render(entry);
 const { title, description, ogImage } = entry.data;

--- a/src/pages/projects/isnad-graph.astro
+++ b/src/pages/projects/isnad-graph.astro
@@ -8,6 +8,7 @@ import ProjectLayout from "../../layouts/ProjectLayout.astro";
 
 const entry = await getEntry("projects", "isnad-graph");
 if (!entry) throw new Error("Missing content entry: projects/isnad-graph");
+if (entry.data.draft) return Astro.redirect("/404");
 
 const { Content } = await render(entry);
 const { title, description, ogImage, features, cta } = entry.data;

--- a/tests/unit/content-schema.test.ts
+++ b/tests/unit/content-schema.test.ts
@@ -43,6 +43,27 @@ describe("Content collection — pages/about.mdx", () => {
   });
 });
 
+describe("Draft filtering (#62) — content consumers honor entry.data.draft", () => {
+  const pagesDir = resolve(contentDir, "../pages");
+
+  it("about.astro redirects drafts to /404", () => {
+    const raw = readFileSync(resolve(pagesDir, "about.astro"), "utf-8");
+    expect(raw).toContain(
+      'if (entry.data.draft) return Astro.redirect("/404")',
+    );
+  });
+
+  it("projects/isnad-graph.astro redirects drafts to /404", () => {
+    const raw = readFileSync(
+      resolve(pagesDir, "projects/isnad-graph.astro"),
+      "utf-8",
+    );
+    expect(raw).toContain(
+      'if (entry.data.draft) return Astro.redirect("/404")',
+    );
+  });
+});
+
 describe("Content config (content.config.ts)", () => {
   const raw = readFileSync(
     resolve(contentDir, "../content.config.ts"),

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -3,10 +3,27 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 const distDir = resolve(import.meta.dirname, "../../dist");
+const srcDir = resolve(import.meta.dirname, "../../src");
 
 function readPage(path: string): string {
   return readFileSync(resolve(distDir, path), "utf-8");
 }
+
+function readSrc(path: string): string {
+  return readFileSync(resolve(srcDir, path), "utf-8");
+}
+
+describe("SEO — Astro.site fallback URL (#62)", () => {
+  const source = readSrc("components/SEO.astro");
+
+  it("falls back to https://www.noorinalabs.com when Astro.site is undefined", () => {
+    expect(source).toContain('"https://www.noorinalabs.com"');
+  });
+
+  it("does not fall back to the wrong .org domain", () => {
+    expect(source).not.toContain("https://noorinalabs.org");
+  });
+});
 
 describe("SEO — JSON-LD structured data", () => {
   const html = readPage("index.html");


### PR DESCRIPTION
## Summary

Closes #62.

Two correctness gaps surfaced in the issue, both addressed.

### 1. SEO fallback URL mismatch

`src/components/SEO.astro:21` previously fell back to `https://noorinalabs.org` when `Astro.site` is undefined. The configured site in `astro.config.mjs:7` is `https://www.noorinalabs.com`. In any render context where `Astro.site` happens to be unset (local probes, ad-hoc renders), the Organization and WebSite JSON-LD schemas would advertise a `.org` domain that does not host the canonical site, with `logo` pointing at an image URL that resolves nowhere.

Aligned the fallback to `https://www.noorinalabs.com`. Kept the fallback rather than removing it so misconfigured probes still emit valid structured data instead of a literal `undefined`.

### 2. Missing draft filter

`src/content.config.ts` defines `draft: z.boolean().default(false)` on both `projects` and `pages` collections, but no consumer filtered drafts. A content file with `draft: true` would still build and publish.

Both consumers — `src/pages/about.astro` and `src/pages/projects/isnad-graph.astro` — now redirect to `/404` when the entry is a draft, matching the suggested fix in the issue. `/404.astro` already exists and builds in static output.

```astro
const entry = await getEntry("pages", "about");
if (!entry) throw new Error("Missing content entry: pages/about");
if (entry.data.draft) return Astro.redirect("/404");
```

Single PR, single commit. Per-PR diff scope: 5 files, +41/-1 lines.

## Test plan

- [x] `npm run build` — green; 4 pages built (`index.html`, `about/`, `projects/isnad-graph/`, `404.html`), sitemap emitted
- [x] `npm test` — 74/74 unit tests pass (up from 70: added 2 SEO-fallback source assertions + 2 draft-redirect consumer assertions)
- [x] `npx prettier --check` — clean on all 5 modified files
- [ ] `npx astro check` — not run locally (requires `@astrojs/check` install which would balloon scope into a `package.json` change unrelated to this PR; CI workflow already runs it per `.github/workflows/ci.yml`)
- [ ] E2E (Playwright) — not run locally; CI runs the full suite. Changes are content-data-flow only, no DOM/visual surface, so e2e regression risk is minimal.

## Out of scope

- Wholesale removal of the `Astro.site` fallback (would change behavior in misconfigured-probe paths without further analysis; current change is the minimal correctness fix).
- Switching to collection-level filter at `getCollection()` query time (only two consumers each use `getEntry()` for a single fixed slug — per-consumer guard is the minimal viable fix and aligns exactly with the issue's suggested pattern).
- Adding a `draft: true` test fixture under `src/content/` (would require committing a content file that does not render, and the source-level assertion already verifies the guard exists in both consumers).

## Acceptance criteria

Both issue items are addressed:
- [x] `SEO.astro` fallback no longer points at the wrong `.org` domain.
- [x] Both content-collection consumers honor `entry.data.draft` by redirecting drafts to `/404`.
