### PR TITLE
feat(nav): mobile hamburger menu (#60)

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -58,7 +58,49 @@ const footerNav = {
         Noorina Labs
       </a>
 
-      <ul role="list">
+      <button
+        type="button"
+        class="nav-toggle"
+        aria-controls="primary-nav"
+        aria-expanded="false"
+        aria-label="Open navigation menu"
+        data-nav-toggle
+      >
+        <svg
+          class="nav-toggle-icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <line
+            class="nav-toggle-line nav-toggle-line-top"
+            x1="3"
+            y1="6"
+            x2="21"
+            y2="6"></line>
+          <line
+            class="nav-toggle-line nav-toggle-line-mid"
+            x1="3"
+            y1="12"
+            x2="21"
+            y2="12"></line>
+          <line
+            class="nav-toggle-line nav-toggle-line-bot"
+            x1="3"
+            y1="18"
+            x2="21"
+            y2="18"></line>
+        </svg>
+      </button>
+
+      <ul id="primary-nav" role="list" data-nav-list>
         {
           headerNav.map((item) => (
             <li>
@@ -69,6 +111,62 @@ const footerNav = {
       </ul>
     </nav>
   </header>
+
+  <script>
+    /*
+     * Mobile-nav disclosure (#60)
+     * ---------------------------
+     * Disclosure pattern: button toggles aria-expanded on itself and data-open
+     * on the <ul>. CSS handles visibility; JS handles state + a11y.
+     * Closes on: Escape, click outside, clicking a nav link.
+     */
+    const toggle =
+      document.querySelector<HTMLButtonElement>("[data-nav-toggle]");
+    const list = document.querySelector<HTMLUListElement>("[data-nav-list]");
+
+    if (toggle && list) {
+      const setOpen = (open: boolean) => {
+        toggle.setAttribute("aria-expanded", String(open));
+        toggle.setAttribute(
+          "aria-label",
+          open ? "Close navigation menu" : "Open navigation menu",
+        );
+        list.dataset.open = String(open);
+      };
+
+      toggle.addEventListener("click", () => {
+        const open = toggle.getAttribute("aria-expanded") === "true";
+        setOpen(!open);
+      });
+
+      list.addEventListener("click", (e) => {
+        if ((e.target as HTMLElement).closest("a")) {
+          setOpen(false);
+        }
+      });
+
+      document.addEventListener("keydown", (e) => {
+        if (
+          e.key === "Escape" &&
+          toggle.getAttribute("aria-expanded") === "true"
+        ) {
+          setOpen(false);
+          toggle.focus();
+        }
+      });
+
+      document.addEventListener("click", (e) => {
+        const target = e.target as Node;
+        if (
+          toggle.getAttribute("aria-expanded") === "true" &&
+          !toggle.contains(target) &&
+          !list.contains(target)
+        ) {
+          setOpen(false);
+        }
+      });
+    }
+  </script>
 
   <!-- Main content -->
   <main id="main-content">
@@ -165,6 +263,93 @@ const footerNav = {
   header a:focus-visible {
     outline: 2px solid var(--color-gold-300);
     outline-offset: 2px;
+  }
+
+  /* --------------------------------------------------------------- */
+  /*  Mobile-nav disclosure (#60)                                    */
+  /* --------------------------------------------------------------- */
+
+  .nav-toggle {
+    display: none;
+    background: transparent;
+    border: 0;
+    padding: 0.5rem;
+    margin: 0;
+    color: var(--color-neutral-50);
+    cursor: pointer;
+    line-height: 0;
+  }
+
+  .nav-toggle:focus-visible {
+    outline: 2px solid var(--color-gold-300);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .nav-toggle-line {
+    transition:
+      transform 0.2s ease,
+      opacity 0.2s ease;
+    transform-origin: center;
+  }
+
+  /* Open state: morph hamburger into close (X) */
+  .nav-toggle[aria-expanded="true"] .nav-toggle-line-top {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .nav-toggle[aria-expanded="true"] .nav-toggle-line-mid {
+    opacity: 0;
+  }
+
+  .nav-toggle[aria-expanded="true"] .nav-toggle-line-bot {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+
+  @media (max-width: 639.98px) {
+    .nav-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    header ul {
+      position: absolute;
+      top: 100%;
+      right: 1.5rem;
+      left: 1.5rem;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.5rem;
+      margin-top: 0.5rem;
+      background: var(--color-navy-900);
+      border: 1px solid var(--color-navy-700);
+      border-radius: 0.5rem;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      display: none;
+    }
+
+    header ul[data-open="true"] {
+      display: flex;
+    }
+
+    header ul a {
+      display: block;
+      padding: 0.75rem 0.75rem;
+      font-size: 1rem;
+      border-radius: 0.25rem;
+    }
+
+    header ul a:hover,
+    header ul a:focus-visible {
+      background: var(--color-navy-800);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-toggle-line {
+      transition: none;
+    }
   }
 
   footer {

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,4 +1,17 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+/*
+ * On viewports below 640px the primary-nav list is collapsed behind a toggle
+ * (#60 mobile hamburger). Tests that exercise header links must first open
+ * the menu — except where they target the footer or the logo, which remain
+ * visible at all sizes.
+ */
+async function openMobileNavIfNeeded(page: Page) {
+  if ((page.viewportSize()?.width ?? 0) < 640) {
+    await page.locator("[data-nav-toggle]").click();
+    await expect(page.locator("#primary-nav")).toBeVisible();
+  }
+}
 
 test.describe("Page navigation", () => {
   test("homepage loads with correct title", async ({ page }) => {
@@ -8,7 +21,8 @@ test.describe("Page navigation", () => {
 
   test("navigate from homepage to about", async ({ page }) => {
     await page.goto("/");
-    await page.click('a[href="/about"]');
+    await openMobileNavIfNeeded(page);
+    await page.locator('#primary-nav a[href="/about"]').click();
     await expect(page).toHaveURL(/\/about/);
     await expect(page).toHaveTitle(/About.*Noorina Labs/);
   });

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -7,10 +7,97 @@ test.describe("Responsive behavior", () => {
     await expect(hero).toBeVisible();
   });
 
-  test("navigation is visible", async ({ page }) => {
+  test("navigation landmark is visible", async ({ page }) => {
     await page.goto("/");
     const nav = page.locator('nav[aria-label="Primary navigation"]');
     await expect(nav).toBeVisible();
+  });
+
+  test("mobile-nav: toggle button visible only on small viewports", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/");
+    const toggle = page.locator("[data-nav-toggle]");
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    if (viewportWidth < 640) {
+      await expect(toggle).toBeVisible();
+    } else {
+      await expect(toggle).toBeHidden();
+    }
+  });
+
+  test("mobile-nav: list hidden by default on small viewports, visible on desktop", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const list = page.locator("#primary-nav");
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    if (viewportWidth < 640) {
+      await expect(list).toBeHidden();
+    } else {
+      await expect(list).toBeVisible();
+    }
+  });
+
+  test("mobile-nav: toggle opens and closes the menu (mobile only)", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      (page.viewportSize()?.width ?? 0) >= 640,
+      "toggle is hidden above 640px",
+    );
+    await page.goto("/");
+    const toggle = page.locator("[data-nav-toggle]");
+    const list = page.locator("#primary-nav");
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).toBeHidden();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(list).toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).toBeHidden();
+  });
+
+  test("mobile-nav: Escape key closes the menu (mobile only)", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? 0) >= 640,
+      "toggle is hidden above 640px",
+    );
+    await page.goto("/");
+    const toggle = page.locator("[data-nav-toggle]");
+    const list = page.locator("#primary-nav");
+
+    await toggle.click();
+    await expect(list).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).toBeHidden();
+  });
+
+  test("mobile-nav: clicking a link closes the menu (mobile only)", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? 0) >= 640,
+      "toggle is hidden above 640px",
+    );
+    await page.goto("/about");
+    const toggle = page.locator("[data-nav-toggle]");
+    const list = page.locator("#primary-nav");
+
+    await toggle.click();
+    await expect(list).toBeVisible();
+
+    await list.locator('a[href="/"]').click();
+    await page.waitForURL("**/");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
   });
 
   test("footer is visible", async ({ page }) => {

--- a/tests/unit/navigation.test.ts
+++ b/tests/unit/navigation.test.ts
@@ -23,6 +23,18 @@ describe("Navigation", () => {
     expect(html).toContain(">Projects</");
   });
 
+  it("renders mobile-nav toggle with disclosure attributes", () => {
+    expect(html).toContain("data-nav-toggle");
+    expect(html).toContain('aria-controls="primary-nav"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-label="Open navigation menu"');
+  });
+
+  it("renders primary-nav list with disclosure target id", () => {
+    expect(html).toContain('id="primary-nav"');
+    expect(html).toContain("data-nav-list");
+  });
+
   it("renders footer with project links", () => {
     expect(html).toContain("Isnad Graph");
   });


### PR DESCRIPTION
Closes #60.

## Summary

Adds a mobile-nav disclosure to `PageLayout.astro`. Below 640px the primary nav `<ul>` collapses behind a hamburger `<button>`; above 640px the header layout is unchanged. Fixes the overflow / wrap-over-logo behavior flagged in the issue.

## Implementation

- **Vanilla TS in `<script>` tag** — no React or Astro island. Keeps the layout's zero-JS-at-idle footprint (~700 bytes of inline script after build).
- **Disclosure pattern** — `<button aria-controls aria-expanded>` toggles `data-open` on the `<ul>`. CSS gates visibility behind the `(max-width: 639.98px)` breakpoint; the button is `display:none` above that breakpoint. No `role="menu"` since the targets are page links, not menu commands (WAI-ARIA-Practices recommendation for a single-trigger collapse).
- **Hamburger-to-X icon** — inline SVG with three `<line>` elements; the top/bottom rotate ±45° and the middle fades to opacity 0 on open. `aria-hidden="true"` + `focusable="false"` so screen readers read the button label, not the icon.

## a11y considerations

- `aria-controls="primary-nav"`, `aria-expanded` flips on toggle, `aria-label` swaps between "Open navigation menu" and "Close navigation menu" with state
- `:focus-visible` outline matches existing site-logo / header-link pattern (`--color-gold-300`, 2px)
- **Escape** closes the menu and returns focus to the toggle
- **Click-outside** (anywhere not inside toggle or list) closes the menu
- **Clicking any nav link** closes the menu before navigating
- `prefers-reduced-motion` disables the icon-morph transition
- Open state still works at viewports ≥640px (no harmful state if JS runs but CSS doesn't apply) — gracefully no-ops

## Test plan

- [x] `npm run build` — green
- [x] `npm test` — **72/72** unit pass (was 70/70, +2 navigation cases asserting disclosure attributes)
- [x] `npx playwright test` — **66 passed, 6 skipped** across `desktop-chromium` / `mobile-chrome` / `tablet`. Skipped tests are mobile-only disclosure-interaction cases that `test.skip` on viewports ≥640px by design (toggle is hidden there).
  - New e2e: viewport-conditional toggle visibility, viewport-conditional list visibility, toggle open/close, Escape closes, link-click closes
  - Existing e2e: `navigate from homepage to about` updated to open mobile nav first on small viewports and scope to `#primary-nav a` (avoids ambiguity with the footer About link)
- [x] `npm run lint` — only pre-existing `RUNBOOK.md` warning (unrelated; same state as wave-10 HEAD `e8cc7fb` — also surfaced by #96)

## Files touched

- `src/layouts/PageLayout.astro` — toggle markup, disclosure script, CSS for breakpoint + open state + icon morph
- `tests/unit/navigation.test.ts` — assert toggle and list disclosure markup
- `tests/e2e/responsive.spec.ts` — viewport-conditional + interaction coverage
- `tests/e2e/navigation.spec.ts` — scope existing "navigate to about" through `#primary-nav` after opening mobile nav

## Out of scope

- Adding a JS dark-mode toggle to the LP — separate concern, PR #96 NOTE already covers token alignment with the DS
- Migrating header-link styling to DS semantic tokens — wider refactor, captured by other follow-ups in #96's body
