### PR TITLE
ci: bump Node-20 docker actions to Node-24 (#102)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,10 +52,10 @@ jobs:
       # a single-arch special case (deploy#242 / closes the option-A path
       # left open by deploy#240).
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tag scheme (isnad-graph#815 Contract v6 = option C, canonical at
@@ -93,7 +93,7 @@ jobs:
             type=raw,value=stg-latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

GitHub forces all actions onto the Node.js 24 runtime on **2026-06-02**. The Node-20-based docker action majors in `.github/workflows/deploy.yml` are deprecated and at risk of breaking after that date. This bumps the four affected pins to their Node-24 majors:

- `docker/setup-buildx-action` `@v3` → `@v4`
- `docker/login-action` `@v3` → `@v4`
- `docker/metadata-action` `@v5` → `@v6`
- `docker/build-push-action` `@v6` → `@v7`

No behavioral change — all four are drop-in major bumps that only move the action's runtime onto Node 24. Grep confirms zero stale `@v3`/`@v5`/`@v6` pins remain for these docker actions across `.github/workflows/`.

## Test plan

- [ ] CI green on this PR
- [ ] On next push to `main`, the `Publish to GHCR` workflow runs clean with no Node-20 deprecation warnings

Closes #102
Refs noorinalabs/noorinalabs-main#536

TechDebt: none