### PR TITLE
ci(branch-protection): port canonical ruleset spec (Refs noorinalabs-main#322)

### DIFF
--- a/.github/branch-protection/SPEC.md
+++ b/.github/branch-protection/SPEC.md
@@ -1,0 +1,90 @@
+# Branch Protection — noorinalabs-landing-page (P3 end-state #4, main#322)
+
+Phase-3 end-state criterion #4 (`noorinalabs-main#322`): **CI failures block all
+merges** on every repo's default branch, org-wide — enforced server-side by
+GitHub, not only by the Hook 4 comment-gate. This directory carries the
+canonical ruleset for this repo's `main`:
+
+| File | Purpose |
+|------|---------|
+| `ruleset-main.json` | The repository ruleset payload (GitHub REST `/rulesets`). |
+| `apply-ruleset.sh`  | Owner/admin-gated apply + read-back-verify. Idempotent (create-or-update). |
+| `SPEC.md`           | This document — the shape and the why. |
+
+This is landing-page's adoption of the parent-canonical spec
+(`noorinalabs-main` charter `pull-requests.md` § *Org-Wide Branch Protection +
+Admin-Merge Exceptions*), modeled on the W13 live pilot
+(`noorinalabs-data-acquisition`, ruleset id `17091263`) and the user-service
+W14 adoption. landing-page is the last of the 8 repos to carry the spec dir.
+
+## Application status
+
+The **spec + apply script** land in this PR (W15, `Refs noorinalabs-main#322`).
+The actual **apply is owner/admin-gated** and is a **post-merge step**:
+
+1. Creating a repository ruleset requires repo-admin permission, which the agent
+   `gh` principal (`parametrization`) does not hold for this purpose.
+2. Applying default-branch protection while a wave-branch PR is in flight can
+   block our own merges, so the apply runs from a window with **no in-flight
+   default-branch merge** — post-wave-wrapup is the safe window.
+
+So #322 is **met for this repo only when the owner (or the org-rollout step,
+TPM Wanjiku Mwangi this wave) has run `apply-ruleset.sh` and read-back-verified
+the ruleset on `main`.** `#322` stays OPEN as the org-wide rollout tracker until
+all 8 default branches carry the protection.
+
+## The ruleset shape (and why)
+
+A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
+
+- **`pull_request` with `required_approving_review_count: 0`** — the load-bearing
+  decision. GitHub's "require approvals" counts **formal** GitHub PR reviews,
+  which our team structurally cannot produce: the `gh` auth principal IS the PR
+  author (`parametrization`), so a formal self-approval **422s**, and our review
+  discipline runs on **issue-comment verdicts** validated by Hook 4
+  (`validate_pr_review`), not formal reviews. A naive "require 1 approval" rule
+  would **deadlock every merge**. Reviewer-count enforcement stays with Hook 4.
+- **`required_status_checks` (strict)** — landing-page has **unconditional PR CI**
+  (no `paths:` filter on `ci.yml`), so the ruleset hard-requires its gate
+  **job-name** contexts:
+
+  | Context | Source job |
+  |---------|-----------|
+  | `Lint, Type Check & Build` | `ci.yml` → `ci` (eslint + tsc + Astro build) |
+  | `E2E Tests (Playwright)` | `ci.yml` → Playwright E2E |
+
+  **Deliberately NOT required:**
+  - The `docs.yml` gates — `Markdown lint`, `Spellcheck (cspell)`,
+    `Internal link-check (lychee)`, `Config — Workflow actionlint`,
+    `Config — YAML/JSON syntax`, `Pre-commit ⇄ CI sync-drift gate` — because
+    `docs.yml` is **`paths:`-filtered**. Requiring a path-filtered check would
+    deadlock any PR that does not touch the matched paths (the check never
+    reports, so a strict ruleset waits forever). The docs gates stay advisory
+    for source-only PRs; they still run-and-block whenever docs/config change.
+  - `Build & Push Docker Image` — that is `deploy.yml`-only, not a PR gate.
+
+  **Re-confirm all contexts at apply time** against live check-runs — job names
+  can change:
+  `gh api repos/<repo>/commits/<default-sha>/check-runs --jq '.check_runs[].name'`.
+- **`deletion` + `non_fast_forward`** — no force-push / branch-delete on `main`.
+- **`bypass_actors`: Repository-admin (`actor_id: 5`, `bypass_mode: always`)** —
+  keeps the orchestrator's `--admin` wave→main wrapup merges and the charter
+  single-reviewer / doc-sweep / emergency exceptions working. The GitHub-side
+  bypass is mirrored on the operator side by the hook-validated
+  `ADMIN_MERGE_EXCEPTION` gate (`validate_pr_ci_status`), which **audits** every
+  `--admin` merge to the Annunaki trail — defense in depth: the ruleset covers
+  UI/external/batch-loop merges, the hook covers `gh pr merge` and names the
+  exceptions.
+
+## How to apply (owner / org-rollout)
+
+```bash
+# From a window with NO in-flight default-branch merge (post-wave-wrapup):
+.github/branch-protection/apply-ruleset.sh            # create or update
+DRY_RUN=1 .github/branch-protection/apply-ruleset.sh  # preview only
+
+# Then read-back-verify the detail (contexts + bypass actor):
+gh api repos/noorinalabs/noorinalabs-landing-page/rulesets \
+  --jq '.[] | select(.name|startswith("Protect main")) | .id'
+gh api repos/noorinalabs/noorinalabs-landing-page/rulesets/<id>
+```

--- a/.github/branch-protection/apply-ruleset.sh
+++ b/.github/branch-protection/apply-ruleset.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Apply the noorinalabs-landing-page default-branch protection ruleset.
+#
+# Phase-3 end-state criterion #4 (noorinalabs-main#322): CI failures block all
+# merges on every repo's default branch, enforced server-side by GitHub (not
+# only by the Hook 4 comment-gate). This script is the OWNER/ADMIN-gated apply
+# step: it POSTs (or, if a same-named ruleset already exists, PUT-updates) the
+# canonical ruleset committed alongside it (ruleset-main.json).
+#
+# Why this is a post-merge, owner-run step — not done in the PR:
+#   Creating/updating a repository ruleset requires repo-admin permission, which
+#   the agent gh principal (parametrization) does not hold for this purpose, and
+#   applying default-branch protection while a wave-branch PR is in flight can
+#   block our own merges. So the durable PR artifact is the SPEC + this script;
+#   the owner runs it from a window with no in-flight default-branch merge
+#   (post-wave-wrapup is the safe window), then read-back-verifies.
+#
+# Design notes (see SPEC.md in this directory + charter pull-requests.md
+# § Org-Wide Branch Protection):
+#   * required_approving_review_count: 0 — GitHub's "require approvals" counts
+#     FORMAL PR reviews, which our team structurally cannot produce (the gh auth
+#     principal IS the PR author, so a formal self-approval 422s). Reviewer-count
+#     enforcement stays with Hook 4 (validate_pr_review). A "require 1 approval"
+#     rule would deadlock every merge.
+#   * Required status checks: landing-page has unconditional PR CI (ci.yml has no
+#     `paths:` filter), so the ruleset hard-requires its gate contexts (job
+#     NAMES, not workflow names): `Lint, Type Check & Build` and
+#     `E2E Tests (Playwright)`. Confirm them against live check-runs at apply
+#     time (`gh api repos/<repo>/commits/<default-sha>/check-runs`) — CI job
+#     names can change. The docs.yml gates (markdown/spellcheck/lychee/actionlint
+#     /YAML-JSON/precommit-ci-sync) are deliberately NOT required: docs.yml is
+#     path-filtered, so requiring them would deadlock any PR that does not touch
+#     docs/config. `Build & Push Docker Image` is deploy.yml-only and likewise
+#     excluded.
+#   * Repository-admin always-bypass (actor_id 5) keeps the orchestrator's
+#     --admin wave→main wrapup merges + the charter single-reviewer/doc-sweep/
+#     emergency exceptions working. The hook-side ADMIN_MERGE_EXCEPTION gate
+#     (validate_pr_ci_status) audits every such bypass.
+#
+# Usage:
+#   ./apply-ruleset.sh                 # apply to noorinalabs/noorinalabs-landing-page
+#   REPO=owner/name ./apply-ruleset.sh # override target repo (for re-use)
+#   DRY_RUN=1 ./apply-ruleset.sh       # print the payload + planned action, no write
+
+set -euo pipefail
+
+REPO="${REPO:-noorinalabs/noorinalabs-landing-page}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PAYLOAD="$SCRIPT_DIR/ruleset-main.json"
+RULESET_NAME="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['name'])" "$PAYLOAD")"
+
+if [[ ! -f "$PAYLOAD" ]]; then
+  echo "ERROR: ruleset payload not found at $PAYLOAD" >&2
+  exit 1
+fi
+
+echo "Repo:    $REPO"
+echo "Ruleset: $RULESET_NAME"
+echo "Payload: $PAYLOAD"
+echo
+
+# Is there already a ruleset with this name? (idempotent re-apply / update.)
+EXISTING_ID="$(gh api "repos/$REPO/rulesets" \
+  --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || true)"
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  echo "DRY_RUN — would $( [[ -n "$EXISTING_ID" ]] && echo "UPDATE ruleset $EXISTING_ID" || echo "CREATE a new ruleset" ):"
+  cat "$PAYLOAD"
+  exit 0
+fi
+
+if [[ -n "$EXISTING_ID" ]]; then
+  echo "Updating existing ruleset id $EXISTING_ID ..."
+  gh api -X PUT "repos/$REPO/rulesets/$EXISTING_ID" --input "$PAYLOAD"
+else
+  echo "Creating new ruleset ..."
+  gh api -X POST "repos/$REPO/rulesets" --input "$PAYLOAD"
+fi
+
+echo
+echo "=== Read-back verification ==="
+gh api "repos/$REPO/rulesets" \
+  --jq ".[] | select(.name == \"$RULESET_NAME\") | {id, name, enforcement, target}"
+echo
+echo "Confirm the required-status-check contexts and bypass actor in the ruleset"
+echo "detail (gh api repos/$REPO/rulesets/<id>) before declaring #322 met for this repo."

--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -1,0 +1,45 @@
+{
+  "name": "Protect main — require PR + green CI (P3 end-state #4, main#322)",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "required_reviewers": [],
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Lint, Type Check & Build" },
+          { "context": "E2E Tests (Playwright)" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Ports the canonical `.github/branch-protection/` spec to **noorinalabs-landing-page** — the last of the 8 org repos still missing the directory. Phase-3 end-state criterion #4 (`Refs noorinalabs-main#322`): CI failures block all merges on `main`, enforced server-side by a GitHub repository ruleset, not only by the Hook 4 comment-gate.

Modeled on user-service's W14 adoption and the W13 data-acquisition live pilot (ruleset id `17091263`).

## Files

| File | Notes |
|------|-------|
| `ruleset-main.json` | `~DEFAULT_BRANCH`, `enforcement: active`. `pull_request` with `required_approving_review_count: 0`, `required_status_checks` (strict), `deletion` + `non_fast_forward`, repo-admin always-bypass (`actor_id: 5`). |
| `apply-ruleset.sh` | Owner/admin-gated, idempotent create-or-update + read-back-verify. Mechanically identical to canonical (diff = only the `REPO` default + the contexts comment). shellcheck clean (0.10.0). `DRY_RUN=1` exercised. |
| `SPEC.md` | Shape + rationale, adapted to landing-page. |

## Required status-check contexts — verified against LIVE check-runs

Verified via `gh api repos/noorinalabs/noorinalabs-landing-page/commits/main/check-runs --jq '.check_runs[].name'`:

- ✅ `Lint, Type Check & Build` — `ci.yml`, **unconditional** (no `paths:` filter, confirmed at HEAD)
- ✅ `E2E Tests (Playwright)` — `ci.yml`, **unconditional**

**Deliberately NOT required (would deadlock merges):**
- `docs.yml` gates (`Markdown lint`, `Spellcheck (cspell)`, `Internal link-check (lychee)`, `Config — Workflow actionlint`, `Config — YAML/JSON syntax`, `Pre-commit ⇄ CI sync-drift gate`) — `docs.yml` is `paths:`-filtered, so a strict ruleset requiring them would wait forever on any PR that does not touch docs/config.
- `Build & Push Docker Image` — `deploy.yml`-only, not a PR gate.

## Why `required_approving_review_count: 0`

GitHub's "require approvals" counts **formal** PR reviews. Our `gh` auth principal IS the PR author (`parametrization`), so a formal self-approval 422s; review discipline runs on issue-comment verdicts validated by Hook 4 (`validate_pr_review`). A "require 1 approval" rule would deadlock every merge. Reviewer-count enforcement stays with Hook 4.

## Scope boundary

This PR delivers the **spec directory only**. The live `gh api .../rulesets POST` application is the org-rollout step (TPM Wanjiku Mwangi), sequenced **after this PR merges**, run from a window with no in-flight default-branch merge, with owner authorization.

Refs noorinalabs-main#322

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
