### PR TITLE
ci(docs): pin actionlint installer to v1.7.12 + SHA256-verify (Refs noorinalabs-main#578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -157,13 +157,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        run: actionlint -color
 
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate


### PR DESCRIPTION
## What

Pins landing-page's `docs.yml` actionlint installer to **v1.7.12 with SHA256 verification**, replacing the unpinned `main`-tracking `curl|bash` of `download-actionlint.bash`. landing-page child slice of `Refs noorinalabs-main#578`.

## Why

The prior step fetched-and-executed the latest-of-`main` `download-actionlint.bash` every run (no version pin, no checksum) — a supply-chain gap that also diverged from the pinned v1.7.12 the `.pre-commit-config.yaml` mirror already ships.

## Change

Single `curl|bash` + `./actionlint -color` step → canonical two-step shape (parent #579 / Santiago's #578 rollout patch):

1. **Download and verify actionlint** — pinned `ACTIONLINT_VERSION=1.7.12` + `ACTIONLINT_SHA256`, `curl` the release tarball, `sha256sum -c` (aborts the job on mismatch), `install` to `/usr/local/bin`.
2. **Run actionlint on workflows** — plain `actionlint -color` (no `./` prefix now the binary is on PATH). landing-page carries **no `-ignore` flags**, so the run line is unchanged besides dropping `./`.

## Verification

- **SHA256** `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8` (`actionlint_1.7.12_linux_amd64.tar.gz`) independently re-verified against upstream's published `actionlint_1.7.12_checksums.txt` before commit (verify-third-party-integrity discipline).
- **`actionlint -color` clean** on the changed workflow locally, with `shellcheck` on PATH so the embedded shellcheck integration actually ran (not silently skipped).
- Job name **`Config — Workflow actionlint` unchanged** — no new required-status-check context, no matrix expansion.

Refs noorinalabs-main#578

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
