### PR TITLE
feat(#520): recover stranded wave-10 feature set (lp#59-#66/#93-#99)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://noorinalabs.com/sitemap-index.xml
+Sitemap: https://www.noorinalabs.com/sitemap-index.xml

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -18,7 +18,7 @@ interface Props {
 const { schemas = [] } = Astro.props;
 
 const siteUrl =
-  Astro.site?.toString().replace(/\/$/, "") ?? "https://noorinalabs.org";
+  Astro.site?.toString().replace(/\/$/, "") ?? "https://www.noorinalabs.com";
 
 const organizationSchema = {
   "@context": "https://schema.org",

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -58,7 +58,49 @@ const footerNav = {
         Noorina Labs
       </a>
 
-      <ul role="list">
+      <button
+        type="button"
+        class="nav-toggle"
+        aria-controls="primary-nav"
+        aria-expanded="false"
+        aria-label="Open navigation menu"
+        data-nav-toggle
+      >
+        <svg
+          class="nav-toggle-icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <line
+            class="nav-toggle-line nav-toggle-line-top"
+            x1="3"
+            y1="6"
+            x2="21"
+            y2="6"></line>
+          <line
+            class="nav-toggle-line nav-toggle-line-mid"
+            x1="3"
+            y1="12"
+            x2="21"
+            y2="12"></line>
+          <line
+            class="nav-toggle-line nav-toggle-line-bot"
+            x1="3"
+            y1="18"
+            x2="21"
+            y2="18"></line>
+        </svg>
+      </button>
+
+      <ul id="primary-nav" role="list" data-nav-list>
         {
           headerNav.map((item) => (
             <li>
@@ -69,6 +111,62 @@ const footerNav = {
       </ul>
     </nav>
   </header>
+
+  <script>
+    /*
+     * Mobile-nav disclosure (#60)
+     * ---------------------------
+     * Disclosure pattern: button toggles aria-expanded on itself and data-open
+     * on the <ul>. CSS handles visibility; JS handles state + a11y.
+     * Closes on: Escape, click outside, clicking a nav link.
+     */
+    const toggle =
+      document.querySelector<HTMLButtonElement>("[data-nav-toggle]");
+    const list = document.querySelector<HTMLUListElement>("[data-nav-list]");
+
+    if (toggle && list) {
+      const setOpen = (open: boolean) => {
+        toggle.setAttribute("aria-expanded", String(open));
+        toggle.setAttribute(
+          "aria-label",
+          open ? "Close navigation menu" : "Open navigation menu",
+        );
+        list.dataset.open = String(open);
+      };
+
+      toggle.addEventListener("click", () => {
+        const open = toggle.getAttribute("aria-expanded") === "true";
+        setOpen(!open);
+      });
+
+      list.addEventListener("click", (e) => {
+        if ((e.target as HTMLElement).closest("a")) {
+          setOpen(false);
+        }
+      });
+
+      document.addEventListener("keydown", (e) => {
+        if (
+          e.key === "Escape" &&
+          toggle.getAttribute("aria-expanded") === "true"
+        ) {
+          setOpen(false);
+          toggle.focus();
+        }
+      });
+
+      document.addEventListener("click", (e) => {
+        const target = e.target as Node;
+        if (
+          toggle.getAttribute("aria-expanded") === "true" &&
+          !toggle.contains(target) &&
+          !list.contains(target)
+        ) {
+          setOpen(false);
+        }
+      });
+    }
+  </script>
 
   <!-- Main content -->
   <main id="main-content">
@@ -165,6 +263,93 @@ const footerNav = {
   header a:focus-visible {
     outline: 2px solid var(--color-gold-300);
     outline-offset: 2px;
+  }
+
+  /* --------------------------------------------------------------- */
+  /*  Mobile-nav disclosure (#60)                                    */
+  /* --------------------------------------------------------------- */
+
+  .nav-toggle {
+    display: none;
+    background: transparent;
+    border: 0;
+    padding: 0.5rem;
+    margin: 0;
+    color: var(--color-neutral-50);
+    cursor: pointer;
+    line-height: 0;
+  }
+
+  .nav-toggle:focus-visible {
+    outline: 2px solid var(--color-gold-300);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .nav-toggle-line {
+    transition:
+      transform 0.2s ease,
+      opacity 0.2s ease;
+    transform-origin: center;
+  }
+
+  /* Open state: morph hamburger into close (X) */
+  .nav-toggle[aria-expanded="true"] .nav-toggle-line-top {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .nav-toggle[aria-expanded="true"] .nav-toggle-line-mid {
+    opacity: 0;
+  }
+
+  .nav-toggle[aria-expanded="true"] .nav-toggle-line-bot {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+
+  @media (max-width: 639.98px) {
+    .nav-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    header ul {
+      position: absolute;
+      top: 100%;
+      right: 1.5rem;
+      left: 1.5rem;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.5rem;
+      margin-top: 0.5rem;
+      background: var(--color-navy-900);
+      border: 1px solid var(--color-navy-700);
+      border-radius: 0.5rem;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      display: none;
+    }
+
+    header ul[data-open="true"] {
+      display: flex;
+    }
+
+    header ul a {
+      display: block;
+      padding: 0.75rem 0.75rem;
+      font-size: 1rem;
+      border-radius: 0.25rem;
+    }
+
+    header ul a:hover,
+    header ul a:focus-visible {
+      background: var(--color-navy-800);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-toggle-line {
+      transition: none;
+    }
   }
 
   footer {

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -57,7 +57,7 @@ const {
 
     {
       cta && (
-        <a href={cta.href} class="cta-button" role="link">
+        <a href={cta.href} class="cta-button">
           {cta.label}
         </a>
       )

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,121 @@
+---
+import PageLayout from "../layouts/PageLayout.astro";
+---
+
+<PageLayout
+  title="Page not found"
+  description="The page you were looking for could not be found."
+>
+  <section class="not-found" aria-labelledby="not-found-heading">
+    <div class="not-found-container">
+      <p class="status-code" aria-hidden="true">404</p>
+      <h1 id="not-found-heading">Page not found</h1>
+      <p class="not-found-message">
+        The page you were looking for doesn&rsquo;t exist or may have moved.
+      </p>
+      <div class="not-found-actions">
+        <a href="/" class="btn-primary">Return home</a>
+        <a href="/about" class="btn-secondary">About Noorina Labs</a>
+      </div>
+    </div>
+  </section>
+</PageLayout>
+
+<style>
+  .not-found {
+    min-height: calc(100vh - 8rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6rem 1.5rem 4rem;
+    background: var(--color-navy-50);
+  }
+
+  .not-found-container {
+    max-width: 36rem;
+    text-align: center;
+  }
+
+  .status-code {
+    font-family: var(--font-heading);
+    font-size: clamp(4rem, 12vw, 7rem);
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-gold-500);
+    margin-bottom: 1rem;
+  }
+
+  h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 700;
+    color: var(--color-navy-900);
+    margin-bottom: 1rem;
+  }
+
+  .not-found-message {
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    color: var(--color-navy-700);
+    margin-bottom: 2rem;
+    line-height: 1.6;
+  }
+
+  .not-found-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    font-family: var(--font-body);
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: 0.375rem;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .btn-primary {
+    background: var(--color-navy-700);
+    color: var(--color-neutral-50);
+  }
+
+  .btn-primary:hover {
+    background: var(--color-navy-800);
+  }
+
+  .btn-primary:focus-visible {
+    outline: 2px solid var(--color-gold-400);
+    outline-offset: 2px;
+  }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--color-navy-700);
+    border: 1px solid var(--color-navy-700);
+  }
+
+  .btn-secondary:hover {
+    background: var(--color-navy-700);
+    color: var(--color-neutral-50);
+  }
+
+  .btn-secondary:focus-visible {
+    outline: 2px solid var(--color-gold-400);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .btn-primary,
+    .btn-secondary {
+      transition: none;
+    }
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,6 +10,7 @@ import PageLayout from "../layouts/PageLayout.astro";
 
 const entry = await getEntry("pages", "about");
 if (!entry) throw new Error("Missing content entry: pages/about");
+if (entry.data.draft) return Astro.redirect("/404");
 
 const { Content } = await render(entry);
 const { title, description, ogImage } = entry.data;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,6 +40,7 @@ import SEO from "../components/SEO.astro";
   <!-- Guiding Principle -->
   <section class="section" aria-labelledby="principle-heading">
     <div class="section-container principle-container">
+      <h2 id="principle-heading" class="sr-only">Guiding Principle</h2>
       <blockquote class="principle-quote">
         <p>
           Noorina Labs will never privilege one school of thought, one
@@ -111,28 +112,28 @@ import SEO from "../components/SEO.astro";
         questions that existing tools cannot.
       </p>
       <div class="capabilities-grid">
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Cross-Collection Search</h3>
           <p>
             Search narrators and hadith across major Sunni and Shia collections
             simultaneously — no more switching between siloed databases.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Graph Explorer</h3>
           <p>
             Visualize narrator networks as an interactive graph. Zoom, filter,
             and trace transmission paths between any two narrators.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Cross-Tradition Comparison</h3>
           <p>
             Compare narrator assessments across Sunni and Shia traditions
             side-by-side. Discover shared narrators and divergent evaluations.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Historical Context</h3>
           <p>
             Biographical profiles with teacher-student relationships,
@@ -140,7 +141,7 @@ import SEO from "../components/SEO.astro";
             rijal literature.
           </p>
         </div>
-        <div class="capability-card">
+        <div class="card card-surface">
           <h3>Collection-Level Analysis</h3>
           <p>
             Understand the structure of individual hadith collections — most
@@ -161,7 +162,7 @@ import SEO from "../components/SEO.astro";
     <div class="section-container">
       <h2 id="why-now-heading" class="section-title">Why Now</h2>
       <div class="why-now-grid">
-        <div class="why-now-card">
+        <div class="card card-center">
           <h3>Computational tools have matured</h3>
           <p>
             Graph databases, network analysis, and natural language processing
@@ -169,7 +170,7 @@ import SEO from "../components/SEO.astro";
             replace — hadith scholarship.
           </p>
         </div>
-        <div class="why-now-card">
+        <div class="card card-center">
           <h3>Open data is available</h3>
           <p>
             Digitized hadith collections and biographical dictionaries are now
@@ -177,7 +178,7 @@ import SEO from "../components/SEO.astro";
             possible for the first time.
           </p>
         </div>
-        <div class="why-now-card">
+        <div class="card card-center">
           <h3>Institutional appetite is growing</h3>
           <p>
             Universities, research centers, and Islamic institutions are
@@ -201,7 +202,7 @@ import SEO from "../components/SEO.astro";
         funders who share our commitment to open, rigorous, and inclusive tools.
       </p>
       <div class="partnership-grid">
-        <div class="partnership-card">
+        <div class="card card-surface">
           <h3>Research Partnership</h3>
           <p>
             Collaborate on data curation, scholarly review, and new analytical
@@ -209,7 +210,7 @@ import SEO from "../components/SEO.astro";
             meets the standards of the tradition.
           </p>
         </div>
-        <div class="partnership-card">
+        <div class="card card-surface">
           <h3>Institutional License</h3>
           <p>
             Integrate the Isnad Graph into your university or research center.
@@ -217,7 +218,7 @@ import SEO from "../components/SEO.astro";
             available for academic institutions.
           </p>
         </div>
-        <div class="partnership-card">
+        <div class="card card-surface">
           <h3>Grant & Philanthropic</h3>
           <p>
             Support open-source infrastructure for Islamic scholarship. Grants
@@ -387,98 +388,9 @@ import SEO from "../components/SEO.astro";
     justify-content: center;
   }
 
-  /* Buttons */
-  .btn-primary {
-    display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background: var(--color-gold-500);
-    color: var(--color-navy-950);
-    font-family: var(--font-body);
-    font-weight: 600;
-    font-size: 0.95rem;
-    border-radius: 0.375rem;
-    text-decoration: none;
-    transition:
-      background-color 0.2s ease,
-      transform 0.15s ease;
-  }
-
-  .btn-primary:hover {
-    background: var(--color-gold-400);
-  }
-
-  .btn-primary:focus-visible {
-    outline: 2px solid var(--color-gold-300);
-    outline-offset: 2px;
-  }
-
-  .btn-primary:active {
-    transform: scale(0.98);
-  }
-
-  .btn-secondary {
-    display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background: transparent;
-    color: var(--color-neutral-100);
-    font-family: var(--font-body);
-    font-weight: 600;
-    font-size: 0.95rem;
-    border: 1.5px solid var(--color-navy-300);
-    border-radius: 0.375rem;
-    text-decoration: none;
-    transition:
-      border-color 0.2s ease,
-      color 0.2s ease;
-  }
-
-  .btn-secondary:hover {
-    border-color: var(--color-gold-400);
-    color: var(--color-gold-300);
-  }
-
-  .btn-secondary:focus-visible {
-    outline: 2px solid var(--color-gold-300);
-    outline-offset: 2px;
-  }
-
-  /* Sections */
-  .section {
-    padding: 5rem 1.5rem;
-  }
-
-  .section-alt {
-    background: var(--color-neutral-50);
-  }
-
-  .section-container {
-    max-width: 64rem;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-size: clamp(1.5rem, 3vw, 2.25rem);
-    font-weight: 700;
-    color: var(--color-navy-800);
-    text-align: center;
-    margin-bottom: 3rem;
-  }
-
-  .section-intro {
-    font-family: var(--font-body);
-    font-size: 1.05rem;
-    line-height: 1.8;
-    color: var(--color-neutral-700);
-    text-align: center;
-    max-width: 48rem;
-    margin: 0 auto 2.5rem;
-  }
-
-  .section-cta {
-    text-align: center;
-    margin-top: 2.5rem;
-  }
+  /* Buttons, section helpers, and shared card primitives are defined globally
+     in src/styles/global.css (extracted in #59). Hero/principle/grid styles
+     and one-off page-specific styles remain scoped below. */
 
   /* Guiding Principle */
   .principle-container {
@@ -563,29 +475,8 @@ import SEO from "../components/SEO.astro";
     }
   }
 
-  .capability-card {
-    padding: 2rem;
-    background: var(--color-neutral-50);
-    border-radius: 0.75rem;
-    border: 1px solid var(--color-neutral-200);
-  }
-
-  .capability-card h3 {
-    font-family: var(--font-heading);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-navy-800);
-    margin-bottom: 0.75rem;
-  }
-
-  .capability-card p {
-    font-family: var(--font-body);
-    font-size: 0.925rem;
-    line-height: 1.7;
-    color: var(--color-neutral-600);
-  }
-
-  /* Why Now Grid */
+  /* Why Now Grid — distinct breakpoint/gap from capabilities; card visuals
+     come from .card.card-center in global.css */
   .why-now-grid {
     display: grid;
     gap: 2rem;
@@ -598,27 +489,8 @@ import SEO from "../components/SEO.astro";
     }
   }
 
-  .why-now-card {
-    text-align: center;
-    padding: 2rem 1.5rem;
-  }
-
-  .why-now-card h3 {
-    font-family: var(--font-heading);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-navy-800);
-    margin-bottom: 0.75rem;
-  }
-
-  .why-now-card p {
-    font-family: var(--font-body);
-    font-size: 0.925rem;
-    line-height: 1.7;
-    color: var(--color-neutral-600);
-  }
-
-  /* Partnership Grid */
+  /* Partnership Grid — same shape as why-now but card visuals come from
+     .card.card-surface in global.css */
   .partnership-grid {
     display: grid;
     gap: 2rem;
@@ -631,38 +503,8 @@ import SEO from "../components/SEO.astro";
     }
   }
 
-  .partnership-card {
-    padding: 2rem;
-    background: var(--color-neutral-50);
-    border-radius: 0.75rem;
-    border: 1px solid var(--color-neutral-200);
-  }
-
-  .partnership-card h3 {
-    font-family: var(--font-heading);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-navy-800);
-    margin-bottom: 0.75rem;
-  }
-
-  .partnership-card p {
-    font-family: var(--font-body);
-    font-size: 0.925rem;
-    line-height: 1.7;
-    color: var(--color-neutral-600);
-  }
-
   /* Contact */
   .contact-container {
     text-align: center;
-  }
-
-  /* Reduced motion */
-  @media (prefers-reduced-motion: reduce) {
-    .btn-primary,
-    .btn-secondary {
-      transition: none;
-    }
   }
 </style>

--- a/src/pages/projects/isnad-graph.astro
+++ b/src/pages/projects/isnad-graph.astro
@@ -8,6 +8,7 @@ import ProjectLayout from "../../layouts/ProjectLayout.astro";
 
 const entry = await getEntry("projects", "isnad-graph");
 if (!entry) throw new Error("Missing content entry: projects/isnad-graph");
+if (entry.data.draft) return Astro.redirect("/404");
 
 const { Content } = await render(entry);
 const { title, description, ogImage, features, cta } = entry.data;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,46 +5,72 @@
  * ==================
  * The design system (@noorinalabs/design-system/styles.css) is imported in
  * BaseLayout.astro and provides semantic tokens (--color-primary, --color-background,
- * --font-heading, --font-body, etc.).
+ * --font-heading, --font-body, etc.) plus brand tokens (--color-brand-navy,
+ * --color-brand-gold) in OKLCH.
  *
- * The LP retains navy/gold/neutral as Tailwind @theme extensions so existing
- * utility classes (bg-navy-800, text-gold-400) continue to work.
+ * The LP retains its 11-step navy/gold/neutral scales as Tailwind @theme extensions
+ * so existing utility classes (bg-navy-800, text-gold-400) continue to work without
+ * touching ~130 call sites. Scales are expressed in OKLCH for perceptual uniformity;
+ * dark mode is a single-axis lightness flip rather than 30 paired hex literals.
+ *
+ * Brand alignment with DS:
+ *   --color-navy-500  ← --color-brand-navy   (oklch(0.25 0.05 265))
+ *   --color-gold-500  ← --color-brand-gold   (oklch(0.75 0.12 80))
+ * Other scale steps stay LP-local since DS only ships three brand tones; the scale's
+ * other rungs interpolate hue/chroma around those anchors.
+ *
+ * NOTE: --color-brand-navy and --color-brand-gold were added to DS source at commit
+ * a9207f55 (2026-04-12), but the DS publish workflow has been broken since the
+ * v0.0.1 release (2026-04-06) — the v0.0.1 dist predates brand-token-add by six
+ * days and contains no brand custom properties, and no 0.0.2 or 0.0.3 tag/release
+ * has been cut despite the source bumps (DS main package.json reads 0.0.2). The
+ * LP's ^0.0.2 pin resolves to a v0.0.2 artifact present on the registry (integrity-
+ * pinned in package-lock.json), but that artifact was published outside the recorded
+ * CI publish-run history and its dist contents are not auditable from origin — it
+ * may or may not include the brand custom properties depending on which source
+ * snapshot it was cut from. Inline OKLCH fallbacks on the var() references are
+ * therefore load-bearing for runtime brand identity; they match DS source byte-for-
+ * byte and remain the canonical runtime source until the DS publish pipeline is
+ * repaired.
  */
 
 @theme {
-  --color-navy-50: #f0f2f8;
-  --color-navy-100: #d9ddef;
-  --color-navy-200: #b3bce0;
-  --color-navy-300: #8d9ad0;
-  --color-navy-400: #6779c1;
-  --color-navy-500: #4157b1;
-  --color-navy-600: #34468e;
-  --color-navy-700: #27346a;
-  --color-navy-800: #1a2347;
-  --color-navy-900: #0d1123;
-  --color-navy-950: #070b16;
+  /* ----- Navy: brand-aligned at 500; OKLCH lightness ladder around hue 265 ----- */
+  --color-navy-50: oklch(0.97 0.012 265);
+  --color-navy-100: oklch(0.92 0.022 265);
+  --color-navy-200: oklch(0.83 0.038 265);
+  --color-navy-300: oklch(0.72 0.055 265);
+  --color-navy-400: oklch(0.6 0.072 265);
+  --color-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
+  --color-navy-600: oklch(0.4 0.058 265);
+  --color-navy-700: oklch(0.32 0.052 265);
+  --color-navy-800: oklch(0.24 0.045 265);
+  --color-navy-900: oklch(0.16 0.034 265);
+  --color-navy-950: oklch(0.1 0.024 265);
 
-  --color-gold-50: #fdf9ef;
-  --color-gold-100: #faf0d5;
-  --color-gold-200: #f4dfab;
-  --color-gold-300: #edcc7a;
-  --color-gold-400: #e5b84a;
-  --color-gold-500: #d4a22e;
-  --color-gold-600: #b08424;
-  --color-gold-700: #8c671c;
-  --color-gold-800: #694c15;
-  --color-gold-900: #45310e;
+  /* ----- Gold: brand-aligned at 500; OKLCH lightness ladder around hue 80 ----- */
+  --color-gold-50: oklch(0.98 0.014 80);
+  --color-gold-100: oklch(0.95 0.034 80);
+  --color-gold-200: oklch(0.9 0.062 80);
+  --color-gold-300: oklch(0.84 0.09 80);
+  --color-gold-400: oklch(0.8 0.11 80);
+  --color-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
+  --color-gold-600: oklch(0.65 0.118 80);
+  --color-gold-700: oklch(0.54 0.104 80);
+  --color-gold-800: oklch(0.43 0.084 80);
+  --color-gold-900: oklch(0.33 0.064 80);
 
-  --color-neutral-50: #fafaf9;
-  --color-neutral-100: #f5f5f4;
-  --color-neutral-200: #e7e5e4;
-  --color-neutral-300: #d6d3d1;
-  --color-neutral-400: #a8a29e;
-  --color-neutral-500: #78716c;
-  --color-neutral-600: #57534e;
-  --color-neutral-700: #44403c;
-  --color-neutral-800: #292524;
-  --color-neutral-900: #1c1917;
+  /* ----- Neutral: warm-grey ladder; hue 85 matches DS muted family ----- */
+  --color-neutral-50: oklch(0.98 0.004 85);
+  --color-neutral-100: oklch(0.95 0.006 85);
+  --color-neutral-200: oklch(0.9 0.008 85);
+  --color-neutral-300: oklch(0.83 0.01 85);
+  --color-neutral-400: oklch(0.7 0.01 85);
+  --color-neutral-500: oklch(0.55 0.01 85);
+  --color-neutral-600: oklch(0.45 0.01 85);
+  --color-neutral-700: oklch(0.36 0.009 85);
+  --color-neutral-800: oklch(0.25 0.008 85);
+  --color-neutral-900: oklch(0.18 0.006 85);
 
   /* Surface / text aliases for LP — maps to DS semantic tokens */
   --color-surface: var(--color-background);
@@ -52,47 +78,189 @@
 }
 
 /*
- * Dark mode overrides (#98)
- * The DS provides dark-mode semantic tokens via prefers-color-scheme.
- * Here we adjust the LP-specific navy/gold/neutral palette.
+ * Dark mode
+ * ---------
+ * Single-axis lightness flip across each scale: each step swaps with its
+ * mirror (50 <-> 950 for navy; 50 <-> 900 for gold/neutral). Because the
+ * light scale is now expressed in OKLCH, this can be done by symmetric
+ * lightness substitution while hue and chroma stay constant — preserving
+ * brand identity across modes. Visual parity with the previous hand-tuned
+ * hex inversion is maintained (same perceptual L values reused).
+ *
+ * The DS semantic surface/foreground tokens flip via the DS's own dark-mode
+ * block, so cards, text, and chrome remain consistent.
  */
 @media (prefers-color-scheme: dark) {
   @theme {
-    --color-navy-50: #070b16;
-    --color-navy-100: #0d1123;
-    --color-navy-200: #1a2347;
-    --color-navy-300: #27346a;
-    --color-navy-400: #34468e;
-    --color-navy-500: #4157b1;
-    --color-navy-600: #6779c1;
-    --color-navy-700: #8d9ad0;
-    --color-navy-800: #b3bce0;
-    --color-navy-900: #d9ddef;
-    --color-navy-950: #f0f2f8;
+    --color-navy-50: oklch(0.1 0.024 265);
+    --color-navy-100: oklch(0.16 0.034 265);
+    --color-navy-200: oklch(0.24 0.045 265);
+    --color-navy-300: oklch(0.32 0.052 265);
+    --color-navy-400: oklch(0.4 0.058 265);
+    --color-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
+    --color-navy-600: oklch(0.6 0.072 265);
+    --color-navy-700: oklch(0.72 0.055 265);
+    --color-navy-800: oklch(0.83 0.038 265);
+    --color-navy-900: oklch(0.92 0.022 265);
+    --color-navy-950: oklch(0.97 0.012 265);
 
-    --color-gold-50: #45310e;
-    --color-gold-100: #694c15;
-    --color-gold-200: #8c671c;
-    --color-gold-300: #b08424;
-    --color-gold-400: #d4a22e;
-    --color-gold-500: #e5b84a;
-    --color-gold-600: #edcc7a;
-    --color-gold-700: #f4dfab;
-    --color-gold-800: #faf0d5;
-    --color-gold-900: #fdf9ef;
+    --color-gold-50: oklch(0.33 0.064 80);
+    --color-gold-100: oklch(0.43 0.084 80);
+    --color-gold-200: oklch(0.54 0.104 80);
+    --color-gold-300: oklch(0.65 0.118 80);
+    --color-gold-400: oklch(0.75 0.12 80);
+    --color-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
+    --color-gold-600: oklch(0.84 0.09 80);
+    --color-gold-700: oklch(0.9 0.062 80);
+    --color-gold-800: oklch(0.95 0.034 80);
+    --color-gold-900: oklch(0.98 0.014 80);
 
-    --color-neutral-50: #1c1917;
-    --color-neutral-100: #292524;
-    --color-neutral-200: #44403c;
-    --color-neutral-300: #57534e;
-    --color-neutral-400: #78716c;
-    --color-neutral-500: #a8a29e;
-    --color-neutral-600: #d6d3d1;
-    --color-neutral-700: #e7e5e4;
-    --color-neutral-800: #f5f5f4;
-    --color-neutral-900: #fafaf9;
+    --color-neutral-50: oklch(0.18 0.006 85);
+    --color-neutral-100: oklch(0.25 0.008 85);
+    --color-neutral-200: oklch(0.36 0.009 85);
+    --color-neutral-300: oklch(0.45 0.01 85);
+    --color-neutral-400: oklch(0.55 0.01 85);
+    --color-neutral-500: oklch(0.7 0.01 85);
+    --color-neutral-600: oklch(0.83 0.01 85);
+    --color-neutral-700: oklch(0.9 0.008 85);
+    --color-neutral-800: oklch(0.95 0.006 85);
+    --color-neutral-900: oklch(0.98 0.004 85);
 
     --color-surface: var(--color-background);
     --color-text: var(--color-foreground);
   }
+}
+
+/*
+ * Shared primitives (#59)
+ * -----------------------
+ * Buttons, section helpers, and card typography extracted from
+ * src/pages/index.astro. These are page-agnostic — visual concerns live here;
+ * page-specific layout (hero, principle-container, contact-container, the
+ * three grid breakpoint specs) stays scoped to the consuming page.
+ *
+ * Card typography (.card h3, .card p) is shared across capability cards,
+ * why-now cards, and partnership cards; surface and alignment variants are
+ * applied via .card-surface and .card-center modifiers.
+ */
+
+/* Buttons */
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: var(--color-gold-500);
+  color: var(--color-navy-950);
+  transition:
+    background-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.btn-primary:hover {
+  background: var(--color-gold-400);
+}
+
+.btn-primary:active {
+  transform: scale(0.98);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--color-neutral-100);
+  border: 1.5px solid var(--color-navy-300);
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.btn-secondary:hover {
+  border-color: var(--color-gold-400);
+  color: var(--color-gold-300);
+}
+
+.btn-primary:focus-visible,
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--color-gold-300);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-primary,
+  .btn-secondary {
+    transition: none;
+  }
+}
+
+/* Section helpers */
+.section {
+  padding: 5rem 1.5rem;
+}
+
+.section-alt {
+  background: var(--color-neutral-50);
+}
+
+.section-container {
+  max-width: 64rem;
+  margin: 0 auto;
+}
+
+.section-title {
+  font-family: var(--font-heading);
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  font-weight: 700;
+  color: var(--color-navy-800);
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-intro {
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--color-neutral-700);
+  text-align: center;
+  max-width: 48rem;
+  margin: 0 auto 2.5rem;
+}
+
+.section-cta {
+  text-align: center;
+  margin-top: 2.5rem;
+}
+
+/* Card primitives — shared typography across capability/why-now/partnership */
+.card h3 {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-navy-800);
+  margin-bottom: 0.75rem;
+}
+
+.card p {
+  font-family: var(--font-body);
+  font-size: 0.925rem;
+  line-height: 1.7;
+  color: var(--color-neutral-600);
+}
+
+.card-surface {
+  padding: 2rem;
+  background: var(--color-neutral-50);
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-neutral-200);
+}
+
+.card-center {
+  text-align: center;
+  padding: 2rem 1.5rem;
 }

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,4 +1,17 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+/*
+ * On viewports below 640px the primary-nav list is collapsed behind a toggle
+ * (#60 mobile hamburger). Tests that exercise header links must first open
+ * the menu — except where they target the footer or the logo, which remain
+ * visible at all sizes.
+ */
+async function openMobileNavIfNeeded(page: Page) {
+  if ((page.viewportSize()?.width ?? 0) < 640) {
+    await page.locator("[data-nav-toggle]").click();
+    await expect(page.locator("#primary-nav")).toBeVisible();
+  }
+}
 
 test.describe("Page navigation", () => {
   test("homepage loads with correct title", async ({ page }) => {
@@ -8,7 +21,8 @@ test.describe("Page navigation", () => {
 
   test("navigate from homepage to about", async ({ page }) => {
     await page.goto("/");
-    await page.click('a[href="/about"]');
+    await openMobileNavIfNeeded(page);
+    await page.locator('#primary-nav a[href="/about"]').click();
     await expect(page).toHaveURL(/\/about/);
     await expect(page).toHaveTitle(/About.*Noorina Labs/);
   });

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -7,10 +7,97 @@ test.describe("Responsive behavior", () => {
     await expect(hero).toBeVisible();
   });
 
-  test("navigation is visible", async ({ page }) => {
+  test("navigation landmark is visible", async ({ page }) => {
     await page.goto("/");
     const nav = page.locator('nav[aria-label="Primary navigation"]');
     await expect(nav).toBeVisible();
+  });
+
+  test("mobile-nav: toggle button visible only on small viewports", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/");
+    const toggle = page.locator("[data-nav-toggle]");
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    if (viewportWidth < 640) {
+      await expect(toggle).toBeVisible();
+    } else {
+      await expect(toggle).toBeHidden();
+    }
+  });
+
+  test("mobile-nav: list hidden by default on small viewports, visible on desktop", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const list = page.locator("#primary-nav");
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    if (viewportWidth < 640) {
+      await expect(list).toBeHidden();
+    } else {
+      await expect(list).toBeVisible();
+    }
+  });
+
+  test("mobile-nav: toggle opens and closes the menu (mobile only)", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      (page.viewportSize()?.width ?? 0) >= 640,
+      "toggle is hidden above 640px",
+    );
+    await page.goto("/");
+    const toggle = page.locator("[data-nav-toggle]");
+    const list = page.locator("#primary-nav");
+
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).toBeHidden();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(list).toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).toBeHidden();
+  });
+
+  test("mobile-nav: Escape key closes the menu (mobile only)", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? 0) >= 640,
+      "toggle is hidden above 640px",
+    );
+    await page.goto("/");
+    const toggle = page.locator("[data-nav-toggle]");
+    const list = page.locator("#primary-nav");
+
+    await toggle.click();
+    await expect(list).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).toBeHidden();
+  });
+
+  test("mobile-nav: clicking a link closes the menu (mobile only)", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? 0) >= 640,
+      "toggle is hidden above 640px",
+    );
+    await page.goto("/about");
+    const toggle = page.locator("[data-nav-toggle]");
+    const list = page.locator("#primary-nav");
+
+    await toggle.click();
+    await expect(list).toBeVisible();
+
+    await list.locator('a[href="/"]').click();
+    await page.waitForURL("**/");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
   });
 
   test("footer is visible", async ({ page }) => {
@@ -21,13 +108,17 @@ test.describe("Responsive behavior", () => {
 
   test("capability cards are rendered", async ({ page }) => {
     await page.goto("/");
-    const cards = page.locator(".capability-card");
+    const cards = page.locator(
+      'section[aria-labelledby="capabilities-heading"] .card-surface',
+    );
     await expect(cards).toHaveCount(5);
   });
 
   test("partnership cards are rendered", async ({ page }) => {
     await page.goto("/");
-    const cards = page.locator(".partnership-card");
+    const cards = page.locator(
+      'section[aria-labelledby="partnership-heading"] .card-surface',
+    );
     await expect(cards).toHaveCount(3);
   });
 });

--- a/tests/unit/content-schema.test.ts
+++ b/tests/unit/content-schema.test.ts
@@ -43,6 +43,27 @@ describe("Content collection — pages/about.mdx", () => {
   });
 });
 
+describe("Draft filtering (#62) — content consumers honor entry.data.draft", () => {
+  const pagesDir = resolve(contentDir, "../pages");
+
+  it("about.astro redirects drafts to /404", () => {
+    const raw = readFileSync(resolve(pagesDir, "about.astro"), "utf-8");
+    expect(raw).toContain(
+      'if (entry.data.draft) return Astro.redirect("/404")',
+    );
+  });
+
+  it("projects/isnad-graph.astro redirects drafts to /404", () => {
+    const raw = readFileSync(
+      resolve(pagesDir, "projects/isnad-graph.astro"),
+      "utf-8",
+    );
+    expect(raw).toContain(
+      'if (entry.data.draft) return Astro.redirect("/404")',
+    );
+  });
+});
+
 describe("Content config (content.config.ts)", () => {
   const raw = readFileSync(
     resolve(contentDir, "../content.config.ts"),

--- a/tests/unit/navigation.test.ts
+++ b/tests/unit/navigation.test.ts
@@ -23,6 +23,18 @@ describe("Navigation", () => {
     expect(html).toContain(">Projects</");
   });
 
+  it("renders mobile-nav toggle with disclosure attributes", () => {
+    expect(html).toContain("data-nav-toggle");
+    expect(html).toContain('aria-controls="primary-nav"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-label="Open navigation menu"');
+  });
+
+  it("renders primary-nav list with disclosure target id", () => {
+    expect(html).toContain('id="primary-nav"');
+    expect(html).toContain("data-nav-list");
+  });
+
   it("renders footer with project links", () => {
     expect(html).toContain("Isnad Graph");
   });

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -3,10 +3,27 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 const distDir = resolve(import.meta.dirname, "../../dist");
+const srcDir = resolve(import.meta.dirname, "../../src");
 
 function readPage(path: string): string {
   return readFileSync(resolve(distDir, path), "utf-8");
 }
+
+function readSrc(path: string): string {
+  return readFileSync(resolve(srcDir, path), "utf-8");
+}
+
+describe("SEO — Astro.site fallback URL (#62)", () => {
+  const source = readSrc("components/SEO.astro");
+
+  it("falls back to https://www.noorinalabs.com when Astro.site is undefined", () => {
+    expect(source).toContain('"https://www.noorinalabs.com"');
+  });
+
+  it("does not fall back to the wrong .org domain", () => {
+    expect(source).not.toContain("https://noorinalabs.org");
+  });
+});
 
 describe("SEO — JSON-LD structured data", () => {
   const html = readPage("index.html");


### PR DESCRIPTION
## Summary

Recovers the **entire wave-10 feature set** for `noorinalabs-landing-page` — 19 commits that shipped to `deployments/phase-3/wave-10` but never reached `main`.

**Refs noorinalabs-main#520**
**Recovers lp#59/#60/#61/#62/#63/#66/#93/#94/#97/#98/#99 (stranded on wave-10)**

## Recovery strategy

`main`'s `src/` was last touched **2026-04-12** (design-system alignment, P2W7 Phase B). Audit confirmed **zero** post-wave-10 main commits touch `src/`, `public/robots.txt`, or `tests/` — so the wave-10 versions of these internally-consistent files (hamburger + dark-mode + primitives all co-edit `global.css`/`PageLayout.astro`) are recovered wholesale via `git checkout origin/deployments/phase-3/wave-10 -- src/ public/robots.txt tests/`. Nothing on main is superseded.

## What's recovered

| Feature | Issue(s) | Files |
|---|---|---|
| Mobile hamburger nav | #60 / #99 | `PageLayout.astro` |
| Dark-mode OKLCH palette | #66 | `global.css` |
| a11y fixes (aria-labelledby, drop `role="link"`) | #61 / #94 | layouts |
| SEO fallback + draft filter | #62 / #98 | `SEO.astro`, `index.astro` |
| 404 page + robots.txt www-canonical | #63 / #93 | `404.astro`, `robots.txt` |
| CSS button/section/card primitives | #59 / #97 | `global.css` |
| Unit + e2e tests for the above | — | `tests/` |

## Deliberately NOT recovered

- `package.json` / `package-lock.json` — **identical** on main and wave-10 (no dep churn).
- `.claude/` files, wave bookkeeping.
- branch-protection / docs-CI infra — main-only, added W13/W14; out of scope.

## Test Plan

Ran main's current `ci.yml` gates locally (deps installed against GHCR via `read:packages` token; `.npmrc` never committed with a token):

- `npx prettier --check "src/**/*.{ts,tsx,astro,css,md,json}"` — **PASS** (all files conform)
- `npx eslint .` — **PASS** (exit 0)
- `npx astro check` — **PASS** (0 errors, 0 warnings, 22 files)
- `npm run build` — **environment-blocked locally** (pre-existing toolchain issue, see below), **CI-verified**
- `npm test` (vitest) — 14/14 assertions **PASS**; the 4 "failed files" are cascade ENOENT on `dist/index.html` because the local build couldn't produce `dist/` — **CI-verified** (CI runs Build before Unit tests in the same job)
- `npx playwright test` (e2e) — not run locally (no browsers installed) — **CI-verified**

**Pre-existing local build incompatibility:** `npm run build` fails locally with `[@tailwindcss/vite] Missing field tsconfigPaths on BindingViteResolvePluginConfig` — a rolldown/vite version mismatch in this WSL dev environment. **Reproduced identically on a pristine `origin/main` checkout** (stashed recovery, rebuilt main → same error), proving it is NOT introduced by this PR. The latest CI run on `main` is green, and CI builds against the committed lockfile in a clean runner. This PR does not modify `package.json`/lockfile.
