### PR TITLE
ci(#520): recover auto-close-issues workflow (lp#95)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,35 @@
+name: Auto-close issues
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Close referenced issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const matches = body.matchAll(/[Cc]loses?\s+#(\d+)/g);
+            for (const match of matches) {
+              const issue_number = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `Closed by PR #${context.payload.pull_request.number} merged into \`${context.payload.pull_request.base.ref}\`.`,
+              });
+            }


### PR DESCRIPTION
## Summary

Recovers `.github/workflows/auto-close-issues.yml`, stranded on `deployments/phase-3/wave-10` and never merged to `main` (confirmed absent from main today).

**Refs noorinalabs-main#520**
**Recovers lp#95 (stranded on wave-10)**

## What it does

On a **merged** PR (`pull_request: closed` + `merged == true`), parses the PR body for `Closes #N` references, closes each referenced issue via the REST API, and posts a comment recording which PR / base-ref closed it. This is the org-wide auto-close behavior the owner approved. Permissions scoped to `issues: write`.

## Test Plan

- `actionlint .github/workflows/auto-close-issues.yml` — **PASS** (exit 0, with shellcheck on PATH)

No source/runtime build impact — this is a GitHub Actions workflow only.
