### PR TITLE
fix(landing-page): polish subroutes, icons, favicon, dark-mode (#69)

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Noorina Labs">
+  <!--
+    Noorina Labs mark — "noor" (light) over a navy field.
+    An eight-point star (a recurring motif in Islamic geometric art) in brand
+    gold, centred on the deep-navy brand square. Colours are the brand anchors
+    used across the site (navy #16213e, gold #d4a22e); kept as literal hex so
+    the icon renders identically regardless of CSS-variable availability.
+  -->
+  <rect width="32" height="32" rx="6" fill="#16213e"/>
+  <path
+    fill="#d4a22e"
+    d="M16 4 18.4 9.9 24 7.5 21.6 13.4 27.5 16 21.6 18.6 24 24.5 18.4 22.1 16 28 13.6 22.1 8 24.5 10.4 18.6 4.5 16 10.4 13.4 8 7.5 13.6 9.9Z"
+  />
+  <circle cx="16" cy="16" r="3.1" fill="#16213e"/>
+</svg>

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,0 +1,83 @@
+---
+/**
+ * Icon — inline SVG icon set for the landing page.
+ *
+ * The design system ships its icons as React components
+ * (@noorinalabs/design-system peers on react/react-dom), but this site is
+ * pure Astro with no React renderer. Rather than pull in a React runtime for a
+ * handful of marketing icons, we inline a small set of SVGs that follow the
+ * same DS convention: 24×24, stroke-based, `currentColor`, inline-friendly.
+ *
+ * Names map 1:1 to the `icon` values in the project content collection
+ * frontmatter (src/content/projects/*.mdx). An unknown name renders nothing
+ * (the `aria-hidden` wrapper in the consuming layout still collapses cleanly).
+ */
+interface Props {
+  /** Icon name — must match a key in `paths` below. */
+  name: string;
+  /** Pixel size of the square viewport. */
+  size?: number;
+  /** Extra class names forwarded to the <svg>. */
+  class?: string;
+}
+
+const { name, size = 24, class: className } = Astro.props;
+
+/*
+ * Each entry is the inner markup of a 24×24 icon. Strokes use currentColor so
+ * the icon inherits the surrounding text colour and responds to theme changes.
+ */
+const paths: Record<string, string> = {
+  // graph — three connected nodes (transmission network)
+  graph: `
+    <circle cx="6" cy="6" r="2.2" />
+    <circle cx="18" cy="7" r="2.2" />
+    <circle cx="12" cy="18" r="2.2" />
+    <line x1="7.7" y1="7.3" x2="10.6" y2="16.4" />
+    <line x1="16.4" y1="8.5" x2="13.2" y2="16.5" />
+    <line x1="8" y1="6.4" x2="15.8" y2="6.8" />
+  `,
+  // user — narrator / person
+  user: `
+    <circle cx="12" cy="8" r="3.5" />
+    <path d="M5 20a7 7 0 0 1 14 0" />
+  `,
+  // search — magnifying glass
+  search: `
+    <circle cx="10.5" cy="10.5" r="6" />
+    <line x1="15" y1="15" x2="20" y2="20" />
+  `,
+  // compare — two overlapping panels (cross-tradition comparison)
+  compare: `
+    <rect x="3" y="5" width="9" height="14" rx="1.5" />
+    <path d="M14 7h5a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1h-3" />
+    <line x1="12" y1="3" x2="12" y2="21" />
+  `,
+  // book — scholarly source
+  book: `
+    <path d="M4 5.5A1.5 1.5 0 0 1 5.5 4H12v15H5.5A1.5 1.5 0 0 0 4 20.5Z" />
+    <path d="M20 5.5A1.5 1.5 0 0 0 18.5 4H12v15h6.5A1.5 1.5 0 0 1 20 20.5Z" />
+  `,
+};
+
+const inner = paths[name] ?? "";
+---
+
+{
+  inner && (
+    <svg
+      class={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      set:html={inner}
+    />
+  )
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,14 @@
 ---
-import "../styles/global.css";
+/*
+ * Import order is load-bearing (#69): the design system ships generic utility
+ * classes (.btn-primary, .feature-card, .section) that collide by name with the
+ * landing page's brand-styled equivalents. Importing the DS *first* lets
+ * global.css win at equal specificity, so brand buttons render gold (not the DS
+ * primary orange) and LP section spacing is preserved. The DS utility classes
+ * the LP does not redefine still apply.
+ */
 import "@noorinalabs/design-system/styles.css";
+import "../styles/global.css";
 
 /* Font loading (#99) — IBM Plex + Noto Naskh Arabic */
 import "@fontsource/ibm-plex-sans/400.css";
@@ -78,8 +86,9 @@ const resolvedOgImage = ogImage.startsWith("http")
     <meta name="twitter:image" content={resolvedOgImage} />
     <meta name="twitter:image:alt" content={ogImageAlt} />
 
-    <!-- Favicon (placeholder — replace with brand asset) -->
+    <!-- Favicon — brand mark (#69) -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="mask-icon" href="/favicon.svg" color="#16213e" />
 
     <!-- Slot for per-page <head> additions (structured data, preloads, etc.) -->
     <slot name="head" />

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -11,6 +11,7 @@
  * Used by: /projects/[slug] routes (e.g., /projects/isnad-graph)
  */
 import PageLayout from "./PageLayout.astro";
+import Icon from "../components/Icon.astro";
 
 interface Feature {
   title: string;
@@ -72,7 +73,7 @@ const {
           <article class="feature-card">
             {feature.icon && (
               <span class="feature-icon" aria-hidden="true">
-                {feature.icon}
+                <Icon name={feature.icon} size={28} />
               </span>
             )}
             <h2>{feature.title}</h2>
@@ -88,3 +89,195 @@ const {
     <slot />
   </section>
 </PageLayout>
+
+<style>
+  /*
+   * Project showcase styles (#69)
+   * -----------------------------
+   * ProjectLayout previously shipped no <style> block, so /projects/[slug]
+   * rendered hero, feature grid, CTA, and MDX body with zero component CSS.
+   * These rules are scoped (Astro adds a data-attribute), which also gives
+   * .feature-card the specificity it needs to win over the design system's
+   * own generic .feature-card link-card rule. Colours come from the LP brand
+   * scales / DS semantic tokens so they flip correctly in dark mode.
+   */
+
+  /* Hero */
+  .project-hero {
+    padding: 7rem 1.5rem 3rem;
+    max-width: 56rem;
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  .project-hero h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 5vw, 3.25rem);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    color: var(--color-navy-800);
+    margin-bottom: 1.25rem;
+  }
+
+  .project-description {
+    font-family: var(--font-body);
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    line-height: 1.7;
+    color: var(--color-neutral-600);
+    max-width: 40rem;
+    margin: 0 auto 2rem;
+  }
+
+  /* Feature grid */
+  .features-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: 1fr;
+    max-width: 64rem;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 3rem;
+  }
+
+  @media (min-width: 640px) {
+    .features-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .features-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .feature-card {
+    padding: 1.75rem;
+    background: var(--color-neutral-50);
+    border: 1px solid var(--color-neutral-200);
+    border-radius: 0.75rem;
+  }
+
+  .feature-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    margin-bottom: 1rem;
+    border-radius: 0.625rem;
+    background: var(--color-gold-100);
+    color: var(--color-gold-700);
+  }
+
+  .feature-card h2 {
+    font-family: var(--font-heading);
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--color-navy-800);
+    margin-bottom: 0.5rem;
+  }
+
+  .feature-card p {
+    font-family: var(--font-body);
+    font-size: 0.925rem;
+    line-height: 1.7;
+    color: var(--color-neutral-600);
+  }
+
+  /* CTA button — brand gold, matches the homepage .btn-primary */
+  .cta-button {
+    display: inline-block;
+    padding: 0.75rem 1.75rem;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 0.95rem;
+    border-radius: 0.375rem;
+    text-decoration: none;
+    background: var(--color-gold-500);
+    color: var(--color-navy-950);
+    transition:
+      background-color 0.2s ease,
+      transform 0.15s ease;
+  }
+
+  .cta-button:hover {
+    background: var(--color-gold-400);
+  }
+
+  .cta-button:active {
+    transform: scale(0.98);
+  }
+
+  .cta-button:focus-visible {
+    outline: 2px solid var(--color-gold-300);
+    outline-offset: 2px;
+  }
+
+  /* MDX body content */
+  .project-content {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 5rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cta-button {
+      transition: none;
+    }
+  }
+</style>
+
+<!--
+  Long-form prose styling for the MDX slot. The headings/paragraphs/lists are
+  rendered by Astro's MDX integration outside this component's scope, so the
+  .prose rules are applied globally (still namespaced under .project-content).
+-->
+<style is:global>
+  .project-content.prose h2 {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-navy-800);
+    margin: 2.5rem 0 1rem;
+  }
+
+  .project-content.prose h3 {
+    font-family: var(--font-heading);
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--color-navy-800);
+    margin: 2rem 0 0.75rem;
+  }
+
+  .project-content.prose p {
+    font-family: var(--font-body);
+    font-size: 1.05rem;
+    line-height: 1.8;
+    color: var(--color-neutral-700);
+    margin-bottom: 1.25rem;
+  }
+
+  .project-content.prose ul {
+    margin: 0 0 1.25rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .project-content.prose li {
+    font-family: var(--font-body);
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--color-neutral-700);
+  }
+
+  .project-content.prose a {
+    color: var(--color-gold-700);
+    text-decoration: underline;
+  }
+
+  .project-content.prose em {
+    color: var(--color-navy-700);
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -27,3 +27,82 @@ const { title, description, ogImage } = entry.data;
     <Content />
   </article>
 </PageLayout>
+
+<style>
+  /*
+   * About-page typography (#69)
+   * about.astro previously had no <style> block, so the MDX body rendered as
+   * unstyled prose. These rules give it a readable measure and brand-consistent
+   * headings. The page wrapper is scoped; the MDX body is styled via the global
+   * block below (rendered outside this component's scope).
+   */
+  .about-page {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 7rem 1.5rem 5rem;
+  }
+
+  .about-page > h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    color: var(--color-navy-800);
+    margin-bottom: 1.5rem;
+  }
+</style>
+
+<style is:global>
+  .about-page h2 {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-navy-800);
+    margin: 2.5rem 0 1rem;
+  }
+
+  .about-page h3 {
+    font-family: var(--font-heading);
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--color-navy-800);
+    margin: 2rem 0 0.75rem;
+  }
+
+  .about-page p {
+    font-family: var(--font-body);
+    font-size: 1.05rem;
+    line-height: 1.8;
+    color: var(--color-neutral-700);
+    margin-bottom: 1.25rem;
+  }
+
+  .about-page ul {
+    margin: 0 0 1.25rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .about-page li {
+    font-family: var(--font-body);
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--color-neutral-700);
+  }
+
+  .about-page a {
+    color: var(--color-gold-700);
+    text-decoration: underline;
+  }
+
+  .about-page strong {
+    color: var(--color-navy-800);
+    font-weight: 700;
+  }
+
+  .about-page em {
+    color: var(--color-navy-700);
+  }
+</style>


### PR DESCRIPTION
Closes #69

## Summary

Resolves the four polish symptom classes in the consolidated landing-page issue. The issue's symptom table was captured 2026-04-19, before the #59/#99 CSS-pipeline refactor, so several originally-reported symptoms were already partly addressed and the **current** root causes differ. All fixes here are grounded in build-output ground truth (per-route stylesheet counts + bundled-CSS cascade order), not the stale report.

| # | Symptom | Verified current root cause | Fix |
|---|---------|------------------------------|-----|
| 1 | Subroutes ship without component CSS | `ProjectLayout.astro` had **no `<style>` block** → `/projects/[slug]` rendered hero/feature-grid/CTA/MDX body with zero component CSS. `about.astro` also had no styles. (`/about` already gets the shared `PageLayout.css`, so it is not "0 stylesheets" today — but its MDX prose was unstyled.) | Added scoped styles to `ProjectLayout` (`.project-hero`, `.features-grid`, `.feature-card`, `.cta-button`) + a namespaced `.project-content.prose` global block; added `.about-page` typography to `about.astro`. |
| 2 | Icons render as literal text | `ProjectLayout` output `{feature.icon}` directly → "graph", "user", … The DS Icon set is **React-only** (peers on react/react-dom); this site is pure Astro. | Per the issue's stopgap guidance, added a React-free `Icon.astro` with inline 24×24 stroke/`currentColor` SVGs following the DS convention; render `<Icon name={feature.icon} />`. |
| 3 | Favicon 404 | `public/` had no favicon asset. | Authored `public/favicon.svg` (navy/gold eight-point-star brand mark) + `mask-icon` link. |
| 4 | Dark-mode / colour clashes | DS utility classes (`.btn-primary`, `.feature-card`, `.section`) collide by name with the LP brand equivalents, and DS loaded **after** `global.css` → DS primary-orange overrode LP gold buttons at equal specificity. | Swapped `BaseLayout` import order (DS first, `global.css` last) so LP brand rules win the cascade; DS classes the LP doesn't redefine still apply. The LP dark-mode token block already flips correctly once brand rules win. |

> Symptom #5 (CTA target IA decision) is an explicit separate UX/IA decision in the issue body, not a CSS-pipeline bug — left out of this PR; can be tracked separately if desired.

## Test Plan

Full local CI parity, all green:
- `prettier --check "src/**/*.{ts,tsx,astro,css,md,json}"` ✓
- `eslint .` ✓
- `astro check` → **0 errors**, 0 warnings, 27 pre-existing hints (none from this change) ✓
- `astro build` ✓
- `vitest run` → **76/76** ✓ (incl. the existing favicon-link unit assertion)
- `playwright test --project=desktop-chromium` → **21 passed**, 3 skipped (mobile-only); **axe a11y passes on all three routes** ✓

### Per-route stylesheet counts (built `dist/`, before → after)

| Route | Stylesheets before | Stylesheets after | Component CSS |
|-------|--------------------|--------------------|----------------|
| `/` | 2 | 2 | unchanged (was already styled) |
| `/about` | 1 | 1 | + `.about-page` prose now styled (was unstyled MDX) |
| `/projects/isnad-graph/` | 1 | 1 | **+ all ProjectLayout component CSS** (hero/grid/cards/CTA/prose), previously 0 |
| `/404` | 1 | 1 | unchanged |

(`/about` was **1**, not "0" as in the 2026-04-19 report — the shared `PageLayout.css` carries global.css + DS. The real gap was the project page's missing component CSS and unstyled prose, now fixed.)

### Additional ground-truth checks (live preview)
- `/favicon.svg` → **HTTP 200** (was 404)
- Project-page `.feature-icon` now contains `<svg>` (graph node circle present); **literal-text icon leak = 0**
- Bundled CSS cascade: DS `.btn-primary` (orange) now precedes LP `.btn-primary{background:var(--color-gold-500)}` → **gold wins**

Co-Authored-By: Kofi Mensah-Williams <parametrization+Kofi.Mensah-Williams@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
