### PR TITLE
deps(landing-page): bump @noorinalabs/design-system to ^0.0.4-wave10.0 (#73)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/ibm-plex-sans": "^5.2.8",
         "@fontsource/ibm-plex-serif": "^5.2.7",
         "@fontsource/noto-naskh-arabic": "^5.2.11",
-        "@noorinalabs/design-system": "^0.0.2",
+        "@noorinalabs/design-system": "^0.0.4-wave10.0",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
         "tailwindcss": "^4.2.2"
@@ -1578,14 +1578,18 @@
       }
     },
     "node_modules/@noorinalabs/design-system": {
-      "version": "0.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.2/fe485987807d21365a5f7ca1bf52fac280ddcfb2",
-      "integrity": "sha512-nBJwg++yZtKiLb8TP+J6mPDcKxwvFVN7FcdoHHP6AZxe8gjEwlU//vcCCmAI3BzskACMQqxLDR9w+XkH6fMavQ==",
+      "version": "0.0.4-wave10.0",
+      "resolved": "https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.4-wave10.0/3afa45e7c68364a657aecfc05adb2d0a284fcce5",
+      "integrity": "sha512-W9BKg/rXr5eCEUIQ5iaVbmOjTkDEdsn3XCnBddLuDCs6OF+Zzi/Bgs4ZKb94X1YV4XCjU7YHDSDsugXZXmq3wQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-toast": "^1.2.15",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.5.0"
@@ -2454,6 +2458,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -2501,6 +2534,64 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2769,6 +2860,92 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@fontsource/ibm-plex-sans": "^5.2.8",
     "@fontsource/ibm-plex-serif": "^5.2.7",
     "@fontsource/noto-naskh-arabic": "^5.2.11",
-    "@noorinalabs/design-system": "^0.0.2",
+    "@noorinalabs/design-system": "^0.0.4-wave10.0",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
     "tailwindcss": "^4.2.2"


### PR DESCRIPTION
Closes #73

## Summary

Bumps `@noorinalabs/design-system` from `^0.0.2` to `^0.0.4-wave10.0` and regenerates `package-lock.json`.

### Issue-body correction record

The issue's literal target `^0.0.3` **was never published**. The GH Packages registry has only `0.0.1`, `0.0.2`, and `0.0.4-wave10.0` (current `latest` dist-tag). The org converged on `0.0.4-wave10.0` as the consume target via the sibling consumer **isnad-graph#840 / PR #924** (merged 2026-05-19) — this PR matches that exact caret pin form for cross-repo consistency.

Most of the issue's 2026-04-29 acceptance items were **already satisfied** on the wave branch, so this is a narrow version bump, not the tarball migration the issue body describes:
- `package.json` pin was already `^0.0.2` (registry semver, not a `file:`/tgz reference) — acceptance #1
- `.npmrc` already present with `@noorinalabs:registry=https://npm.pkg.github.com` — acceptance #3
- CI `ci.yml` already wires `setup-node` + `registry-url` + `NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}` on both `npm ci` jobs — acceptance #4. (The issue's step-4 `NPM_TOKEN` suggestion is stale; `NODE_AUTH_TOKEN` is setup-node's canonical env var and is already in place — left unchanged.)

### Interaction with lp#69 / PR #112 (CSS import-order fix)

PR #112 swapped the CSS import order (DS first, `global.css` last) specifically because DS 0.0.2's utility classes collide by name with the LP brand classes. I diffed DS `0.0.2` vs `0.0.4-wave10.0` `styles.css`:

- **0.0.4-wave10.0 removes `.btn-primary` from DS entirely** (along with `.btn*`, `.badge*`, `.form-input*` app-UI classes) — so it no longer name-collides with the LP brand `.btn-primary`.
- `.feature-card` and `.section` still present (still collide by name), but PR #112's import-order swap still correctly makes the LP brand win.
- **Zero new DS selectors added** that could introduce fresh collisions.

Build output confirms: DS `.btn-primary` absent from the DS portion, LP gold `.btn-primary{background:var(--color-gold-500)}` present, DS tokens (`--color-primary` light+dark) present. Net: the bump is collision-safe and slightly **reduces** reliance on the #112 cascade fix.

## Test Plan

Full local CI parity, all green (worktree off wave-branch tip `5612a46`, which includes the merged #112):
- `prettier --check "src/**/*.{ts,tsx,astro,css,md,json}"` — pass
- `eslint .` — pass
- `astro check` — **0 errors, 0 warnings, 27 pre-existing hints** (none from this change)
- `astro build` — pass (4 pages built)
- `vitest run` — **76/76 passed**
- `playwright test --project=desktop-chromium` — **21 passed, 3 skipped** (mobile-only); a11y passes on all three routes

### Acceptance verification
- [x] `package.json` pin uses registry semver (`^0.0.4-wave10.0`)
- [x] `package-lock.json` regenerated — resolves from `https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.4-wave10.0/...`
- [x] `.npmrc` present (pre-existing)
- [x] CI installs via `secrets.GH_PACKAGES_TOKEN` (pre-existing, correct)
- [x] Astro build output contains design-system tokens

Co-Authored-By: Marcia Vasquez-Paredes <parametrization+Marcia.Vasquez-Paredes@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
