### PR TITLE
fix(styles): isnad-graph dark-mode parity via [data-theme] toggle (#43)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -89,46 +89,186 @@
  *
  * The DS semantic surface/foreground tokens flip via the DS's own dark-mode
  * block, so cards, text, and chrome remain consistent.
+ *
+ * isnad-graph parity (#43): the design system flips on TWO axes — the OS
+ * `prefers-color-scheme` media query AND a JS `[data-theme="dark"|"light"]`
+ * attribute toggle on <html> (see DS src/tokens/colors.css). Previously the
+ * LP brand scales flipped only on the media query, so under a future
+ * `data-theme` toggle the DS semantic surface/foreground would invert while
+ * the LP navy/gold/neutral scales stayed in their light values — a split
+ * theme. The dark scale is therefore emitted under both the media query and
+ * `[data-theme="dark"]`; `[data-theme="light"]` pins the scales back to the
+ * light values so an explicit light toggle overrides a dark OS preference,
+ * exactly as the DS does for its semantic tokens.
+ *
+ * The flipped values are shared via the `--dm-*` reference custom properties
+ * below so the two dark triggers (the media query and `[data-theme="dark"]`)
+ * reuse one definition rather than two hand-maintained copies.
+ */
+@theme {
+  /* Dark-mode scale values — single source, referenced by every dark trigger */
+  --dm-navy-50: oklch(0.1 0.024 265);
+  --dm-navy-100: oklch(0.16 0.034 265);
+  --dm-navy-200: oklch(0.24 0.045 265);
+  --dm-navy-300: oklch(0.32 0.052 265);
+  --dm-navy-400: oklch(0.4 0.058 265);
+  --dm-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
+  --dm-navy-600: oklch(0.6 0.072 265);
+  --dm-navy-700: oklch(0.72 0.055 265);
+  --dm-navy-800: oklch(0.83 0.038 265);
+  --dm-navy-900: oklch(0.92 0.022 265);
+  --dm-navy-950: oklch(0.97 0.012 265);
+
+  --dm-gold-50: oklch(0.33 0.064 80);
+  --dm-gold-100: oklch(0.43 0.084 80);
+  --dm-gold-200: oklch(0.54 0.104 80);
+  --dm-gold-300: oklch(0.65 0.118 80);
+  --dm-gold-400: oklch(0.75 0.12 80);
+  --dm-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
+  --dm-gold-600: oklch(0.84 0.09 80);
+  --dm-gold-700: oklch(0.9 0.062 80);
+  --dm-gold-800: oklch(0.95 0.034 80);
+  --dm-gold-900: oklch(0.98 0.014 80);
+
+  --dm-neutral-50: oklch(0.18 0.006 85);
+  --dm-neutral-100: oklch(0.25 0.008 85);
+  --dm-neutral-200: oklch(0.36 0.009 85);
+  --dm-neutral-300: oklch(0.45 0.01 85);
+  --dm-neutral-400: oklch(0.55 0.01 85);
+  --dm-neutral-500: oklch(0.7 0.01 85);
+  --dm-neutral-600: oklch(0.83 0.01 85);
+  --dm-neutral-700: oklch(0.9 0.008 85);
+  --dm-neutral-800: oklch(0.95 0.006 85);
+  --dm-neutral-900: oklch(0.98 0.004 85);
+}
+
+/*
+ * Dark-mode application — shared by the OS media query and the
+ * `[data-theme="dark"]` JS toggle. Both reassign the scale custom properties
+ * to the `--dm-*` dark values, so the two triggers can never drift apart.
  */
 @media (prefers-color-scheme: dark) {
-  @theme {
-    --color-navy-50: oklch(0.1 0.024 265);
-    --color-navy-100: oklch(0.16 0.034 265);
-    --color-navy-200: oklch(0.24 0.045 265);
-    --color-navy-300: oklch(0.32 0.052 265);
-    --color-navy-400: oklch(0.4 0.058 265);
-    --color-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
-    --color-navy-600: oklch(0.6 0.072 265);
-    --color-navy-700: oklch(0.72 0.055 265);
-    --color-navy-800: oklch(0.83 0.038 265);
-    --color-navy-900: oklch(0.92 0.022 265);
-    --color-navy-950: oklch(0.97 0.012 265);
+  :root {
+    --color-navy-50: var(--dm-navy-50);
+    --color-navy-100: var(--dm-navy-100);
+    --color-navy-200: var(--dm-navy-200);
+    --color-navy-300: var(--dm-navy-300);
+    --color-navy-400: var(--dm-navy-400);
+    --color-navy-500: var(--dm-navy-500);
+    --color-navy-600: var(--dm-navy-600);
+    --color-navy-700: var(--dm-navy-700);
+    --color-navy-800: var(--dm-navy-800);
+    --color-navy-900: var(--dm-navy-900);
+    --color-navy-950: var(--dm-navy-950);
 
-    --color-gold-50: oklch(0.33 0.064 80);
-    --color-gold-100: oklch(0.43 0.084 80);
-    --color-gold-200: oklch(0.54 0.104 80);
-    --color-gold-300: oklch(0.65 0.118 80);
-    --color-gold-400: oklch(0.75 0.12 80);
-    --color-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
-    --color-gold-600: oklch(0.84 0.09 80);
-    --color-gold-700: oklch(0.9 0.062 80);
-    --color-gold-800: oklch(0.95 0.034 80);
-    --color-gold-900: oklch(0.98 0.014 80);
+    --color-gold-50: var(--dm-gold-50);
+    --color-gold-100: var(--dm-gold-100);
+    --color-gold-200: var(--dm-gold-200);
+    --color-gold-300: var(--dm-gold-300);
+    --color-gold-400: var(--dm-gold-400);
+    --color-gold-500: var(--dm-gold-500);
+    --color-gold-600: var(--dm-gold-600);
+    --color-gold-700: var(--dm-gold-700);
+    --color-gold-800: var(--dm-gold-800);
+    --color-gold-900: var(--dm-gold-900);
 
-    --color-neutral-50: oklch(0.18 0.006 85);
-    --color-neutral-100: oklch(0.25 0.008 85);
-    --color-neutral-200: oklch(0.36 0.009 85);
-    --color-neutral-300: oklch(0.45 0.01 85);
-    --color-neutral-400: oklch(0.55 0.01 85);
-    --color-neutral-500: oklch(0.7 0.01 85);
-    --color-neutral-600: oklch(0.83 0.01 85);
-    --color-neutral-700: oklch(0.9 0.008 85);
-    --color-neutral-800: oklch(0.95 0.006 85);
-    --color-neutral-900: oklch(0.98 0.004 85);
-
-    --color-surface: var(--color-background);
-    --color-text: var(--color-foreground);
+    --color-neutral-50: var(--dm-neutral-50);
+    --color-neutral-100: var(--dm-neutral-100);
+    --color-neutral-200: var(--dm-neutral-200);
+    --color-neutral-300: var(--dm-neutral-300);
+    --color-neutral-400: var(--dm-neutral-400);
+    --color-neutral-500: var(--dm-neutral-500);
+    --color-neutral-600: var(--dm-neutral-600);
+    --color-neutral-700: var(--dm-neutral-700);
+    --color-neutral-800: var(--dm-neutral-800);
+    --color-neutral-900: var(--dm-neutral-900);
   }
+}
+
+/*
+ * JS toggle override (isnad-graph / DS parity). `[data-theme="dark"]` forces
+ * the dark scales regardless of OS preference; `[data-theme="light"]` forces
+ * the light scales back. Because these are attribute selectors on <html> they
+ * carry higher specificity than the `:root` media-query block above, so an
+ * explicit toggle always wins over the OS default — matching the DS semantic
+ * tokens' behavior and keeping brand + chrome in the same mode.
+ */
+[data-theme="dark"] {
+  --color-navy-50: var(--dm-navy-50);
+  --color-navy-100: var(--dm-navy-100);
+  --color-navy-200: var(--dm-navy-200);
+  --color-navy-300: var(--dm-navy-300);
+  --color-navy-400: var(--dm-navy-400);
+  --color-navy-500: var(--dm-navy-500);
+  --color-navy-600: var(--dm-navy-600);
+  --color-navy-700: var(--dm-navy-700);
+  --color-navy-800: var(--dm-navy-800);
+  --color-navy-900: var(--dm-navy-900);
+  --color-navy-950: var(--dm-navy-950);
+
+  --color-gold-50: var(--dm-gold-50);
+  --color-gold-100: var(--dm-gold-100);
+  --color-gold-200: var(--dm-gold-200);
+  --color-gold-300: var(--dm-gold-300);
+  --color-gold-400: var(--dm-gold-400);
+  --color-gold-500: var(--dm-gold-500);
+  --color-gold-600: var(--dm-gold-600);
+  --color-gold-700: var(--dm-gold-700);
+  --color-gold-800: var(--dm-gold-800);
+  --color-gold-900: var(--dm-gold-900);
+
+  --color-neutral-50: var(--dm-neutral-50);
+  --color-neutral-100: var(--dm-neutral-100);
+  --color-neutral-200: var(--dm-neutral-200);
+  --color-neutral-300: var(--dm-neutral-300);
+  --color-neutral-400: var(--dm-neutral-400);
+  --color-neutral-500: var(--dm-neutral-500);
+  --color-neutral-600: var(--dm-neutral-600);
+  --color-neutral-700: var(--dm-neutral-700);
+  --color-neutral-800: var(--dm-neutral-800);
+  --color-neutral-900: var(--dm-neutral-900);
+}
+
+/*
+ * `[data-theme="light"]` pins the LP scales to their light @theme values so an
+ * explicit light toggle overrides a dark OS preference. (The @theme block at
+ * the top already defines the light values on :root; this selector re-pins
+ * them at attribute-selector specificity to beat the media query.)
+ */
+[data-theme="light"] {
+  --color-navy-50: oklch(0.97 0.012 265);
+  --color-navy-100: oklch(0.92 0.022 265);
+  --color-navy-200: oklch(0.83 0.038 265);
+  --color-navy-300: oklch(0.72 0.055 265);
+  --color-navy-400: oklch(0.6 0.072 265);
+  --color-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
+  --color-navy-600: oklch(0.4 0.058 265);
+  --color-navy-700: oklch(0.32 0.052 265);
+  --color-navy-800: oklch(0.24 0.045 265);
+  --color-navy-900: oklch(0.16 0.034 265);
+  --color-navy-950: oklch(0.1 0.024 265);
+
+  --color-gold-50: oklch(0.98 0.014 80);
+  --color-gold-100: oklch(0.95 0.034 80);
+  --color-gold-200: oklch(0.9 0.062 80);
+  --color-gold-300: oklch(0.84 0.09 80);
+  --color-gold-400: oklch(0.8 0.11 80);
+  --color-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
+  --color-gold-600: oklch(0.65 0.118 80);
+  --color-gold-700: oklch(0.54 0.104 80);
+  --color-gold-800: oklch(0.43 0.084 80);
+  --color-gold-900: oklch(0.33 0.064 80);
+
+  --color-neutral-50: oklch(0.98 0.004 85);
+  --color-neutral-100: oklch(0.95 0.006 85);
+  --color-neutral-200: oklch(0.9 0.008 85);
+  --color-neutral-300: oklch(0.83 0.01 85);
+  --color-neutral-400: oklch(0.7 0.01 85);
+  --color-neutral-500: oklch(0.55 0.01 85);
+  --color-neutral-600: oklch(0.45 0.01 85);
+  --color-neutral-700: oklch(0.36 0.009 85);
+  --color-neutral-800: oklch(0.25 0.008 85);
+  --color-neutral-900: oklch(0.18 0.006 85);
 }
 
 /*


### PR DESCRIPTION
Closes #43

## Summary

Aligns the landing page's **dark-mode mechanism** with the isnad-graph site / shared design system so the two sites behave as one product family.

The investigation found the palette **values** were already at parity — PR #112 had aligned the LP brand anchors (`--color-navy-500`, `--color-gold-500`) to the DS brand tokens (`--color-brand-navy`, `--color-brand-gold`) **byte-for-byte**, and typography/semantic surface tokens already come from the DS. The remaining divergence was the dark-mode *trigger*:

- **isnad-graph + DS** flip on **two axes**: the OS `prefers-color-scheme` media query **and** a JS `[data-theme="dark"|"light"]` attribute toggle on `<html>` (see `noorinalabs-design-system/src/tokens/colors.css`).
- **LP (before)** flipped its brand scales only on the media query. Under a `data-theme` toggle the DS semantic surface/foreground tokens would invert while the LP navy/gold/neutral scales stayed in light values — a split theme.

## Changes (CSS-only — `src/styles/global.css`)

- Extracted the dark scale values into `--dm-*` reference custom properties (single source of truth for the dark values).
- Applied the dark scale under **both** `@media (prefers-color-scheme: dark)` and `[data-theme="dark"]`.
- Added `[data-theme="light"]` to pin the scales to their light values, so an explicit light toggle overrides a dark OS preference — matching how the DS handles its own semantic tokens.

No color **values** changed.

## Before / After

| Aspect | isnad-graph / DS (reference) | LP before | LP after |
|---|---|---|---|
| Brand navy-500 | `--color-brand-navy` = `oklch(0.25 0.05 265)` | `oklch(0.25 0.05 265)` (already matched) | unchanged |
| Brand gold-500 | `--color-brand-gold` = `oklch(0.75 0.12 80)` | `oklch(0.75 0.12 80)` (already matched) | unchanged |
| Typography / surface tokens | DS semantic (`--font-*`, `--color-foreground`…) | DS semantic (already consumed) | unchanged |
| Dark mode: `prefers-color-scheme` | ✅ flips | ✅ flips | ✅ flips |
| Dark mode: `[data-theme="dark"]` toggle | ✅ flips | ❌ scales stayed light (split theme) | ✅ flips |
| Dark mode: `[data-theme="light"]` override | ✅ forces light | ❌ no override | ✅ forces light |

## Test Plan

Full local suite (run in worktree against wave-1 tip, DS v0.0.2 installed):

- `npx eslint .` — clean (exit 0)
- `npx prettier --check "src/**/*.{ts,tsx,astro,css,md,json}"` (CI-exact glob) — clean
- `npx astro check` — 0 errors, 0 warnings
- `npm run build` — success (4 pages)
- `npm test` (vitest) — 76/76 passed
- `npx playwright test --project=desktop-chromium` — 21 passed, 3 skipped (mobile-only)
- Verified built CSS emits `--dm-*` vars on `:root`, plus `[data-theme=dark]` and `[data-theme=light]` scale overrides and the media-query block.

### Notes / caveats
- The installed **DS v0.0.2 dist ships no `--color-brand-*` custom properties** (verified: `grep -c color-brand-navy node_modules/@noorinalabs/design-system/dist/styles.css` → 0). The inline OKLCH fallbacks on the `--dm-navy-500`/`--dm-gold-500` `var()` references are therefore load-bearing at runtime and match DS source. This is consistent with the existing in-file note about the broken DS publish pipeline.
- CSS-only: package.json / package-lock.json untouched (no conflict with Marcia's lp#73 DS bump).
- `npm run lint` (whole-repo `prettier --check .`) flags 5 pre-existing files outside `src/` (`.cspell.json`, `RUNBOOK.md`, `docs/branch-protection.md`, `.markdownlint-cli2.jsonc`, `.github/branch-protection/SPEC.md`) — pre-existing at wave-branch tip and **outside** the CI format-check glob, so not gating and not in this diff.

Co-Authored-By: Cédric Novák <parametrization+Cedric.Novak@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
