### PR TITLE
fix(landing-page): canonical origin = apex host, not www redirect (#120)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,12 @@ import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: "https://www.noorinalabs.com",
+  // Canonical origin is the apex host. Per the deploy Caddy routing,
+  // `noorinalabs.com` is what serves the landing page; `www.noorinalabs.com`
+  // is a 301 redirect to the apex. Pointing `site` at the www host made every
+  // canonical link, og:url, sitemap entry, and JSON-LD url emit a redirect hop
+  // instead of the served origin (#120).
+  site: "https://noorinalabs.com",
   integrations: [mdx(), sitemap()],
   vite: {
     plugins: [tailwindcss()],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.noorinalabs.com/sitemap-index.xml
+Sitemap: https://noorinalabs.com/sitemap-index.xml

--- a/src/content/routes.md
+++ b/src/content/routes.md
@@ -6,18 +6,18 @@ Documented route structure for the Noorina Labs landing page.
 
 ## Route Map
 
-| Route                   | Source                               | Layout          | Collection | Description                                                          |
-| ----------------------- | ------------------------------------ | --------------- | ---------- | -------------------------------------------------------------------- |
-| `/`                     | `src/pages/index.astro`              | `PageLayout`    | —          | Homepage: hero, mission statement, project showcase cards            |
-| `/about`                | `src/pages/about.astro`              | `PageLayout`    | `pages`    | Mission page: renders `src/content/pages/about.mdx`                  |
-| `/projects/isnad-graph` | `src/pages/projects/[...slug].astro` | `ProjectLayout` | `projects` | Project feature page: renders `src/content/projects/isnad-graph.mdx` |
+| Route                   | Source                                 | Layout          | Collection | Description                                                          |
+| ----------------------- | -------------------------------------- | --------------- | ---------- | -------------------------------------------------------------------- |
+| `/`                     | `src/pages/index.astro`                | `PageLayout`    | —          | Homepage: hero, mission statement, project showcase cards            |
+| `/about`                | `src/pages/about.astro`                | `PageLayout`    | `pages`    | Mission page: renders `src/content/pages/about.mdx`                  |
+| `/projects/isnad-graph` | `src/pages/projects/isnad-graph.astro` | `ProjectLayout` | `projects` | Project feature page: renders `src/content/projects/isnad-graph.mdx` |
 
 ---
 
 ## Routing Strategy
 
 - **Static generation.** All routes are pre-rendered at build time (`output: "static"` in Astro config).
-- **Content-driven routes.** `/about` and `/projects/*` are backed by MDX entries in content collections. The `[...slug].astro` dynamic route generates pages from the `projects` collection.
+- **Content-driven routes.** `/about` and `/projects/isnad-graph` are backed by MDX entries in content collections; each project page (e.g. `isnad-graph.astro`) renders its matching `projects` collection entry through `ProjectLayout`.
 - **No client-side routing.** Standard anchor navigation between pages — no SPA behavior.
 
 ---
@@ -56,9 +56,10 @@ BaseLayout.astro
 ### Footer Links
 
 **Projects column:**
-| Label | Href |
-|-------|------|
-| Isnad Graph | `/projects/isnad-graph` |
+| Label | Href | Notes |
+|-------|------|-------|
+| Isnad Graph | `https://isnad-graph.noorinalabs.com` | The live product (app) |
+| About the Isnad Graph | `/projects/isnad-graph` | The project feature page on this site |
 
 **Organization column:**
 | Label | Href |


### PR DESCRIPTION
Closes #120

## What was broken
The landing page is served at the apex **`noorinalabs.com`**; **`www.noorinalabs.com`** is a 301 redirect to it (deploy Caddy routing, per the org service map). But `astro.config.mjs` set Astro's `site` to the **www** host — so every page emitted its `<link rel="canonical">`, `og:url`, twitter meta, absolute OG-image URL, sitemap entry, and JSON-LD `url` against the **redirect host** instead of the served origin. That's a wrong/indirect target on every page (search engines and shares hop through a 301), which is the "links generally broken / nav flow off" the issue describes.

## Changes
- **`astro.config.mjs`** — `site` → `https://noorinalabs.com` (apex). Cascades to canonical, og:url, twitter, OG images, sitemap, and JSON-LD.
- **`public/robots.txt`** — `Sitemap:` → apex (was www; now consistent with the apex-emitting sitemap).
- **`src/content/routes.md`** — nav docs had drifted from the code; refreshed to match reality: project route source is `isnad-graph.astro` (not `[...slug].astro`), and the footer Projects column has two entries (live app `isnad-graph.noorinalabs.com` + on-site project page `/projects/isnad-graph`).

## Audit (every link/nav path)
Checked against the **rendered `dist/` output**, not just source:
- Header nav: `/`, `/about`, `/#projects` (anchor `id="projects"` present on home) — all resolve.
- Footer: `isnad-graph.noorinalabs.com` (live app, correct prod domain), `/projects/isnad-graph`, `/about`, `github.com/noorinalabs` — all correct.
- Hero/section CTAs → `/projects/isnad-graph` and product app; contact → `mailto:info@noorinalabs.com`; skip-link `#main-content`; 404 page links — all resolve.
- No dead internal links or anchors. Product CTA already pointed at the correct prod domain (`isnad-graph.noorinalabs.com`); login/auth lives at `/login` + `/auth/*` on that same app host — no landing-page login CTA exists today, so nothing to re-target (left out of scope to avoid adding new nav).

## Verification
- `npm run build` — clean; `dist/` has **zero** remaining `www.noorinalabs.com` references; canonical/og/sitemap all emit apex.
- `npx astro check` — 0 errors, 0 warnings.
- `prettier --check` — clean on changed source.
- lychee (docs CI) — unaffected: routes.md uses code-span paths, and the one new external URL is excluded by the offline/internal-only config.

## Test plan (runtime, post-deploy)
- Confirm `https://noorinalabs.com/` serves 200 (apex) and `https://www.noorinalabs.com/` 301s to apex.
- View-source a deployed page: canonical + og:url read `https://noorinalabs.com/...`.

Reviewers: @Kofi Mensah-Williams (primary), @Nazia Rahman (secondary).
