### PR TITLE
feat(#118): match isnad-graph look & feel via design-system semantic tokens

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -119,8 +119,8 @@ const resolvedOgImage = ogImage.startsWith("http")
     top: 0;
     z-index: 999;
     padding: 0.5rem 1rem;
-    background: var(--color-surface, #fff);
-    color: var(--color-text, #000);
+    background: var(--color-card);
+    color: var(--color-foreground);
   }
 
   .skip-link:focus {

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -231,12 +231,12 @@ const footerNav = {
     font-family: var(--font-heading);
     font-size: 1.25rem;
     font-weight: 700;
-    color: var(--color-neutral-50);
+    color: var(--color-foreground);
     text-decoration: none;
   }
 
   .site-logo:focus-visible {
-    outline: 2px solid var(--color-gold-300);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
 
@@ -251,17 +251,17 @@ const footerNav = {
   header a {
     font-family: var(--font-body);
     font-size: 0.9rem;
-    color: var(--color-navy-100);
+    color: var(--color-foreground);
     text-decoration: none;
     transition: color 0.15s ease;
   }
 
   header a:hover {
-    color: var(--color-gold-400);
+    color: var(--color-primary);
   }
 
   header a:focus-visible {
-    outline: 2px solid var(--color-gold-300);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
 
@@ -275,13 +275,13 @@ const footerNav = {
     border: 0;
     padding: 0.5rem;
     margin: 0;
-    color: var(--color-neutral-50);
+    color: var(--color-foreground);
     cursor: pointer;
     line-height: 0;
   }
 
   .nav-toggle:focus-visible {
-    outline: 2px solid var(--color-gold-300);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
     border-radius: 2px;
   }
@@ -322,10 +322,10 @@ const footerNav = {
       gap: 0.25rem;
       padding: 0.5rem;
       margin-top: 0.5rem;
-      background: var(--color-navy-900);
-      border: 1px solid var(--color-navy-700);
-      border-radius: 0.5rem;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      background: var(--color-card);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-lg);
       display: none;
     }
 
@@ -342,7 +342,7 @@ const footerNav = {
 
     header ul a:hover,
     header ul a:focus-visible {
-      background: var(--color-navy-800);
+      background: var(--color-muted);
     }
   }
 
@@ -353,8 +353,9 @@ const footerNav = {
   }
 
   footer {
-    background: var(--color-navy-900);
-    color: var(--color-navy-200);
+    background: var(--color-muted);
+    color: var(--color-muted-foreground);
+    border-top: 1px solid var(--color-border);
     padding: 3rem 1.5rem 2rem;
   }
 
@@ -371,7 +372,7 @@ const footerNav = {
     font-family: var(--font-heading);
     font-size: 0.95rem;
     font-weight: 700;
-    color: var(--color-neutral-100);
+    color: var(--color-foreground);
     margin-bottom: 0.75rem;
   }
 
@@ -387,28 +388,28 @@ const footerNav = {
   footer a {
     font-family: var(--font-body);
     font-size: 0.875rem;
-    color: var(--color-navy-200);
+    color: var(--color-muted-foreground);
     text-decoration: none;
     transition: color 0.15s ease;
   }
 
   footer a:hover {
-    color: var(--color-gold-400);
+    color: var(--color-primary);
   }
 
   footer a:focus-visible {
-    outline: 2px solid var(--color-gold-300);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
 
   .footer-copyright {
-    border-top: 1px solid var(--color-navy-700);
+    border-top: 1px solid var(--color-border);
     padding-top: 1.5rem;
     max-width: 64rem;
     margin: 0 auto;
     font-family: var(--font-body);
     font-size: 0.8rem;
-    color: var(--color-navy-400);
+    color: var(--color-muted-foreground);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -116,7 +116,7 @@ const {
     font-weight: 700;
     line-height: 1.15;
     letter-spacing: -0.02em;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin-bottom: 1.25rem;
   }
 
@@ -124,7 +124,7 @@ const {
     font-family: var(--font-body);
     font-size: clamp(1rem, 2vw, 1.2rem);
     line-height: 1.7;
-    color: var(--color-neutral-600);
+    color: var(--color-muted-foreground);
     max-width: 40rem;
     margin: 0 auto 2rem;
   }
@@ -153,9 +153,9 @@ const {
 
   .feature-card {
     padding: 1.75rem;
-    background: var(--color-neutral-50);
-    border: 1px solid var(--color-neutral-200);
-    border-radius: 0.75rem;
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-xl);
   }
 
   .feature-icon {
@@ -165,16 +165,16 @@ const {
     width: 3rem;
     height: 3rem;
     margin-bottom: 1rem;
-    border-radius: 0.625rem;
-    background: var(--color-gold-100);
-    color: var(--color-gold-700);
+    border-radius: var(--radius-lg);
+    background: var(--color-accent);
+    color: var(--color-accent-foreground);
   }
 
   .feature-card h2 {
     font-family: var(--font-heading);
     font-size: 1.15rem;
     font-weight: 700;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin-bottom: 0.5rem;
   }
 
@@ -182,27 +182,27 @@ const {
     font-family: var(--font-body);
     font-size: 0.925rem;
     line-height: 1.7;
-    color: var(--color-neutral-600);
+    color: var(--color-muted-foreground);
   }
 
-  /* CTA button — brand gold, matches the homepage .btn-primary */
+  /* CTA button — DS primary (sienna), matches the homepage .btn-primary */
   .cta-button {
     display: inline-block;
     padding: 0.75rem 1.75rem;
     font-family: var(--font-body);
     font-weight: 600;
     font-size: 0.95rem;
-    border-radius: 0.375rem;
+    border-radius: var(--radius-md);
     text-decoration: none;
-    background: var(--color-gold-500);
-    color: var(--color-navy-950);
+    background: var(--color-primary);
+    color: var(--color-primary-foreground);
     transition:
       background-color 0.2s ease,
       transform 0.15s ease;
   }
 
   .cta-button:hover {
-    background: var(--color-gold-400);
+    background: var(--color-primary-hover);
   }
 
   .cta-button:active {
@@ -210,7 +210,7 @@ const {
   }
 
   .cta-button:focus-visible {
-    outline: 2px solid var(--color-gold-300);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
 
@@ -238,7 +238,7 @@ const {
     font-family: var(--font-heading);
     font-size: 1.5rem;
     font-weight: 700;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin: 2.5rem 0 1rem;
   }
 
@@ -246,7 +246,7 @@ const {
     font-family: var(--font-heading);
     font-size: 1.2rem;
     font-weight: 700;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin: 2rem 0 0.75rem;
   }
 
@@ -254,7 +254,7 @@ const {
     font-family: var(--font-body);
     font-size: 1.05rem;
     line-height: 1.8;
-    color: var(--color-neutral-700);
+    color: var(--color-muted-foreground);
     margin-bottom: 1.25rem;
   }
 
@@ -269,15 +269,15 @@ const {
     font-family: var(--font-body);
     font-size: 1.05rem;
     line-height: 1.7;
-    color: var(--color-neutral-700);
+    color: var(--color-muted-foreground);
   }
 
   .project-content.prose a {
-    color: var(--color-gold-700);
+    color: var(--color-primary);
     text-decoration: underline;
   }
 
   .project-content.prose em {
-    color: var(--color-navy-700);
+    color: var(--color-foreground);
   }
 </style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -28,7 +28,7 @@ import PageLayout from "../layouts/PageLayout.astro";
     align-items: center;
     justify-content: center;
     padding: 6rem 1.5rem 4rem;
-    background: var(--color-navy-50);
+    background: var(--color-muted);
   }
 
   .not-found-container {
@@ -41,7 +41,7 @@ import PageLayout from "../layouts/PageLayout.astro";
     font-size: clamp(4rem, 12vw, 7rem);
     font-weight: 700;
     line-height: 1;
-    color: var(--color-gold-500);
+    color: var(--color-primary);
     margin-bottom: 1rem;
   }
 
@@ -49,14 +49,14 @@ import PageLayout from "../layouts/PageLayout.astro";
     font-family: var(--font-heading);
     font-size: clamp(1.75rem, 4vw, 2.5rem);
     font-weight: 700;
-    color: var(--color-navy-900);
+    color: var(--color-foreground);
     margin-bottom: 1rem;
   }
 
   .not-found-message {
     font-family: var(--font-body);
     font-size: 1.125rem;
-    color: var(--color-navy-700);
+    color: var(--color-muted-foreground);
     margin-bottom: 2rem;
     line-height: 1.6;
   }
@@ -76,39 +76,39 @@ import PageLayout from "../layouts/PageLayout.astro";
     font-size: 1rem;
     font-weight: 600;
     text-decoration: none;
-    border-radius: 0.375rem;
+    border-radius: var(--radius-md);
     transition:
       background-color 0.15s ease,
       color 0.15s ease;
   }
 
   .btn-primary {
-    background: var(--color-navy-700);
-    color: var(--color-neutral-50);
+    background: var(--color-primary);
+    color: var(--color-primary-foreground);
   }
 
   .btn-primary:hover {
-    background: var(--color-navy-800);
+    background: var(--color-primary-hover);
   }
 
   .btn-primary:focus-visible {
-    outline: 2px solid var(--color-gold-400);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
 
   .btn-secondary {
     background: transparent;
-    color: var(--color-navy-700);
-    border: 1px solid var(--color-navy-700);
+    color: var(--color-foreground);
+    border: 1px solid var(--color-border);
   }
 
   .btn-secondary:hover {
-    background: var(--color-navy-700);
-    color: var(--color-neutral-50);
+    background: var(--color-muted);
+    color: var(--color-foreground);
   }
 
   .btn-secondary:focus-visible {
-    outline: 2px solid var(--color-gold-400);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -48,7 +48,7 @@ const { title, description, ogImage } = entry.data;
     font-weight: 700;
     line-height: 1.15;
     letter-spacing: -0.02em;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin-bottom: 1.5rem;
   }
 </style>
@@ -58,7 +58,7 @@ const { title, description, ogImage } = entry.data;
     font-family: var(--font-heading);
     font-size: 1.5rem;
     font-weight: 700;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin: 2.5rem 0 1rem;
   }
 
@@ -66,7 +66,7 @@ const { title, description, ogImage } = entry.data;
     font-family: var(--font-heading);
     font-size: 1.2rem;
     font-weight: 700;
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     margin: 2rem 0 0.75rem;
   }
 
@@ -74,7 +74,7 @@ const { title, description, ogImage } = entry.data;
     font-family: var(--font-body);
     font-size: 1.05rem;
     line-height: 1.8;
-    color: var(--color-neutral-700);
+    color: var(--color-muted-foreground);
     margin-bottom: 1.25rem;
   }
 
@@ -89,20 +89,20 @@ const { title, description, ogImage } = entry.data;
     font-family: var(--font-body);
     font-size: 1.05rem;
     line-height: 1.7;
-    color: var(--color-neutral-700);
+    color: var(--color-muted-foreground);
   }
 
   .about-page a {
-    color: var(--color-gold-700);
+    color: var(--color-primary);
     text-decoration: underline;
   }
 
   .about-page strong {
-    color: var(--color-navy-800);
+    color: var(--color-foreground);
     font-weight: 700;
   }
 
   .about-page em {
-    color: var(--color-navy-700);
+    color: var(--color-foreground);
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -256,66 +256,72 @@ import SEO from "../components/SEO.astro";
     padding: 6rem 1.5rem 4rem;
     background: linear-gradient(
       135deg,
-      var(--color-navy-900) 0%,
-      var(--color-navy-800) 40%,
-      var(--color-navy-700) 100%
+      var(--color-background) 0%,
+      var(--color-muted) 100%
     );
-    color: var(--color-neutral-50);
+    color: var(--color-foreground);
+    border-bottom: 1px solid var(--color-border);
     overflow: hidden;
   }
 
+  /*
+   * Geometric accent — a subtle zellij-style tessellation rendered in the DS
+   * primary (sienna) at low opacity over the warm hero surface. Replaces the
+   * former gold-on-navy pattern so the hero reads in the same palette as the
+   * isnad-graph product.
+   */
   .hero-pattern {
     position: absolute;
     inset: 0;
-    opacity: 0.06;
+    opacity: 0.05;
     background-image:
       linear-gradient(
         30deg,
-        var(--color-gold-400) 12%,
+        var(--color-primary) 12%,
         transparent 12.5%,
         transparent 87%,
-        var(--color-gold-400) 87.5%,
-        var(--color-gold-400)
+        var(--color-primary) 87.5%,
+        var(--color-primary)
       ),
       linear-gradient(
         150deg,
-        var(--color-gold-400) 12%,
+        var(--color-primary) 12%,
         transparent 12.5%,
         transparent 87%,
-        var(--color-gold-400) 87.5%,
-        var(--color-gold-400)
+        var(--color-primary) 87.5%,
+        var(--color-primary)
       ),
       linear-gradient(
         30deg,
-        var(--color-gold-400) 12%,
+        var(--color-primary) 12%,
         transparent 12.5%,
         transparent 87%,
-        var(--color-gold-400) 87.5%,
-        var(--color-gold-400)
+        var(--color-primary) 87.5%,
+        var(--color-primary)
       ),
       linear-gradient(
         150deg,
-        var(--color-gold-400) 12%,
+        var(--color-primary) 12%,
         transparent 12.5%,
         transparent 87%,
-        var(--color-gold-400) 87.5%,
-        var(--color-gold-400)
+        var(--color-primary) 87.5%,
+        var(--color-primary)
       ),
       linear-gradient(
         60deg,
-        var(--color-gold-300) 25%,
+        var(--color-primary) 25%,
         transparent 25.5%,
         transparent 75%,
-        var(--color-gold-300) 75%,
-        var(--color-gold-300)
+        var(--color-primary) 75%,
+        var(--color-primary)
       ),
       linear-gradient(
         60deg,
-        var(--color-gold-300) 25%,
+        var(--color-primary) 25%,
         transparent 25.5%,
         transparent 75%,
-        var(--color-gold-300) 75%,
-        var(--color-gold-300)
+        var(--color-primary) 75%,
+        var(--color-primary)
       );
     background-size: 80px 140px;
     background-position:
@@ -354,7 +360,7 @@ import SEO from "../components/SEO.astro";
     font-family: var(--font-body);
     font-size: clamp(1rem, 2vw, 1.25rem);
     line-height: 1.7;
-    color: var(--color-navy-100);
+    color: var(--color-muted-foreground);
     max-width: 38rem;
     margin: 0 auto 2rem;
   }
@@ -371,14 +377,14 @@ import SEO from "../components/SEO.astro";
     font-family: var(--font-body);
     font-size: 0.85rem;
     font-weight: 600;
-    color: var(--color-gold-300);
+    color: var(--color-primary);
     letter-spacing: 0.02em;
   }
 
   .hero-pillars .pillar:not(:last-child)::after {
     content: "\00b7";
     margin-left: 0.75rem;
-    color: var(--color-navy-400);
+    color: var(--color-border);
   }
 
   .hero-actions {
@@ -398,10 +404,10 @@ import SEO from "../components/SEO.astro";
   }
 
   .principle-quote {
-    border-left: 3px solid var(--color-gold-500);
+    border-left: 3px solid var(--color-primary);
     padding: 1.5rem 1.5rem 1.5rem 2rem;
-    background: var(--color-navy-50);
-    border-radius: 0 0.5rem 0.5rem 0;
+    background: var(--color-muted);
+    border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
   }
 
   .principle-quote p {
@@ -409,7 +415,7 @@ import SEO from "../components/SEO.astro";
     font-size: 1.15rem;
     font-style: italic;
     line-height: 1.7;
-    color: var(--color-navy-700);
+    color: var(--color-foreground);
   }
 
   /* Problem Section */
@@ -426,7 +432,7 @@ import SEO from "../components/SEO.astro";
     font-family: var(--font-body);
     font-size: 1rem;
     line-height: 1.7;
-    color: var(--color-neutral-700);
+    color: var(--color-muted-foreground);
   }
 
   .problem-stats {
@@ -446,14 +452,14 @@ import SEO from "../components/SEO.astro";
     font-family: var(--font-heading);
     font-size: clamp(2rem, 4vw, 3rem);
     font-weight: 700;
-    color: var(--color-navy-800);
+    color: var(--color-primary);
     line-height: 1.1;
   }
 
   .stat-label {
     font-family: var(--font-body);
     font-size: 0.875rem;
-    color: var(--color-neutral-500);
+    color: var(--color-muted-foreground);
   }
 
   /* Capabilities Grid */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,275 +1,37 @@
 @import "tailwindcss";
 
 /*
- * Landing-page theme
- * ==================
- * The design system (@noorinalabs/design-system/styles.css) is imported in
- * BaseLayout.astro and provides semantic tokens (--color-primary, --color-background,
- * --font-heading, --font-body, etc.) plus brand tokens (--color-brand-navy,
- * --color-brand-gold) in OKLCH.
+ * Landing-page theme (#118 — match isnad-graph look & feel)
+ * =========================================================
+ * The landing page now consumes the design system's SEMANTIC tokens directly,
+ * exactly as the isnad-graph app does (see noorinalabs-isnad-graph
+ * frontend/src/styles/theme.css). There is no LP-local colour ladder: every
+ * surface, text, and accent colour resolves to a `@noorinalabs/design-system`
+ * token (--color-primary, --color-background, --color-foreground, --color-card,
+ * --color-muted, --color-border, …), imported in BaseLayout.astro.
  *
- * The LP retains its 11-step navy/gold/neutral scales as Tailwind @theme extensions
- * so existing utility classes (bg-navy-800, text-gold-400) continue to work without
- * touching ~130 call sites. Scales are expressed in OKLCH for perceptual uniformity;
- * dark mode is a single-axis lightness flip rather than 30 paired hex literals.
+ * Why this changed: the LP previously defined a bespoke navy/gold/neutral OKLCH
+ * ladder, which rendered as a cool navy-and-gold marketing site visually
+ * disjoint from isnad-graph's warm parchment/sienna/ink product palette. Folding
+ * the LP onto the same semantic tokens gives one cohesive brand and — because
+ * the DS tokens already flip on `prefers-color-scheme` and the `[data-theme]`
+ * JS toggle — dark mode now comes for free with no LP-side machinery to keep in
+ * sync (the old ~150-line --dm-* mirror is gone).
  *
- * Brand alignment with DS:
- *   --color-navy-500  ← --color-brand-navy   (oklch(0.25 0.05 265))
- *   --color-gold-500  ← --color-brand-gold   (oklch(0.75 0.12 80))
- * Other scale steps stay LP-local since DS only ships three brand tones; the scale's
- * other rungs interpolate hue/chroma around those anchors.
+ * Token cheat-sheet (DS semantic → LP usage):
+ *   --color-background / --color-muted  surfaces (page, alt sections, footer)
+ *   --color-card                        raised card surfaces
+ *   --color-foreground                  headings, strong text
+ *   --color-muted-foreground            body copy, captions, labels
+ *   --color-border                      hairlines, card/border edges
+ *   --color-primary / -hover / -foreground   primary actions, accents (sienna)
+ *   --color-accent / --color-accent-foreground   tinted icon chips
+ *   --color-ring                        focus outlines
+ *   --radius-* / --shadow-*             DS radii + elevation
  *
- * NOTE: --color-brand-navy and --color-brand-gold were added to DS source at commit
- * a9207f55 (2026-04-12), but the DS publish workflow has been broken since the
- * v0.0.1 release (2026-04-06) — the v0.0.1 dist predates brand-token-add by six
- * days and contains no brand custom properties, and no 0.0.2 or 0.0.3 tag/release
- * has been cut despite the source bumps (DS main package.json reads 0.0.2). The
- * LP's ^0.0.2 pin resolves to a v0.0.2 artifact present on the registry (integrity-
- * pinned in package-lock.json), but that artifact was published outside the recorded
- * CI publish-run history and its dist contents are not auditable from origin — it
- * may or may not include the brand custom properties depending on which source
- * snapshot it was cut from. Inline OKLCH fallbacks on the var() references are
- * therefore load-bearing for runtime brand identity; they match DS source byte-for-
- * byte and remain the canonical runtime source until the DS publish pipeline is
- * repaired.
+ * If a needed value is missing from the DS, add it to the DS first and consume
+ * it here — do not reintroduce a bespoke scale (issue #118 hard constraint).
  */
-
-@theme {
-  /* ----- Navy: brand-aligned at 500; OKLCH lightness ladder around hue 265 ----- */
-  --color-navy-50: oklch(0.97 0.012 265);
-  --color-navy-100: oklch(0.92 0.022 265);
-  --color-navy-200: oklch(0.83 0.038 265);
-  --color-navy-300: oklch(0.72 0.055 265);
-  --color-navy-400: oklch(0.6 0.072 265);
-  --color-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
-  --color-navy-600: oklch(0.4 0.058 265);
-  --color-navy-700: oklch(0.32 0.052 265);
-  --color-navy-800: oklch(0.24 0.045 265);
-  --color-navy-900: oklch(0.16 0.034 265);
-  --color-navy-950: oklch(0.1 0.024 265);
-
-  /* ----- Gold: brand-aligned at 500; OKLCH lightness ladder around hue 80 ----- */
-  --color-gold-50: oklch(0.98 0.014 80);
-  --color-gold-100: oklch(0.95 0.034 80);
-  --color-gold-200: oklch(0.9 0.062 80);
-  --color-gold-300: oklch(0.84 0.09 80);
-  --color-gold-400: oklch(0.8 0.11 80);
-  --color-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
-  --color-gold-600: oklch(0.65 0.118 80);
-  --color-gold-700: oklch(0.54 0.104 80);
-  --color-gold-800: oklch(0.43 0.084 80);
-  --color-gold-900: oklch(0.33 0.064 80);
-
-  /* ----- Neutral: warm-grey ladder; hue 85 matches DS muted family ----- */
-  --color-neutral-50: oklch(0.98 0.004 85);
-  --color-neutral-100: oklch(0.95 0.006 85);
-  --color-neutral-200: oklch(0.9 0.008 85);
-  --color-neutral-300: oklch(0.83 0.01 85);
-  --color-neutral-400: oklch(0.7 0.01 85);
-  --color-neutral-500: oklch(0.55 0.01 85);
-  --color-neutral-600: oklch(0.45 0.01 85);
-  --color-neutral-700: oklch(0.36 0.009 85);
-  --color-neutral-800: oklch(0.25 0.008 85);
-  --color-neutral-900: oklch(0.18 0.006 85);
-
-  /* Surface / text aliases for LP — maps to DS semantic tokens */
-  --color-surface: var(--color-background);
-  --color-text: var(--color-foreground);
-}
-
-/*
- * Dark mode
- * ---------
- * Single-axis lightness flip across each scale: each step swaps with its
- * mirror (50 <-> 950 for navy; 50 <-> 900 for gold/neutral). Because the
- * light scale is now expressed in OKLCH, this can be done by symmetric
- * lightness substitution while hue and chroma stay constant — preserving
- * brand identity across modes. Visual parity with the previous hand-tuned
- * hex inversion is maintained (same perceptual L values reused).
- *
- * The DS semantic surface/foreground tokens flip via the DS's own dark-mode
- * block, so cards, text, and chrome remain consistent.
- *
- * isnad-graph parity (#43): the design system flips on TWO axes — the OS
- * `prefers-color-scheme` media query AND a JS `[data-theme="dark"|"light"]`
- * attribute toggle on <html> (see DS src/tokens/colors.css). Previously the
- * LP brand scales flipped only on the media query, so under a future
- * `data-theme` toggle the DS semantic surface/foreground would invert while
- * the LP navy/gold/neutral scales stayed in their light values — a split
- * theme. The dark scale is therefore emitted under both the media query and
- * `[data-theme="dark"]`; `[data-theme="light"]` pins the scales back to the
- * light values so an explicit light toggle overrides a dark OS preference,
- * exactly as the DS does for its semantic tokens.
- *
- * The flipped values are shared via the `--dm-*` reference custom properties
- * below so the two dark triggers (the media query and `[data-theme="dark"]`)
- * reuse one definition rather than two hand-maintained copies.
- */
-@theme {
-  /* Dark-mode scale values — single source, referenced by every dark trigger */
-  --dm-navy-50: oklch(0.1 0.024 265);
-  --dm-navy-100: oklch(0.16 0.034 265);
-  --dm-navy-200: oklch(0.24 0.045 265);
-  --dm-navy-300: oklch(0.32 0.052 265);
-  --dm-navy-400: oklch(0.4 0.058 265);
-  --dm-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
-  --dm-navy-600: oklch(0.6 0.072 265);
-  --dm-navy-700: oklch(0.72 0.055 265);
-  --dm-navy-800: oklch(0.83 0.038 265);
-  --dm-navy-900: oklch(0.92 0.022 265);
-  --dm-navy-950: oklch(0.97 0.012 265);
-
-  --dm-gold-50: oklch(0.33 0.064 80);
-  --dm-gold-100: oklch(0.43 0.084 80);
-  --dm-gold-200: oklch(0.54 0.104 80);
-  --dm-gold-300: oklch(0.65 0.118 80);
-  --dm-gold-400: oklch(0.75 0.12 80);
-  --dm-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
-  --dm-gold-600: oklch(0.84 0.09 80);
-  --dm-gold-700: oklch(0.9 0.062 80);
-  --dm-gold-800: oklch(0.95 0.034 80);
-  --dm-gold-900: oklch(0.98 0.014 80);
-
-  --dm-neutral-50: oklch(0.18 0.006 85);
-  --dm-neutral-100: oklch(0.25 0.008 85);
-  --dm-neutral-200: oklch(0.36 0.009 85);
-  --dm-neutral-300: oklch(0.45 0.01 85);
-  --dm-neutral-400: oklch(0.55 0.01 85);
-  --dm-neutral-500: oklch(0.7 0.01 85);
-  --dm-neutral-600: oklch(0.83 0.01 85);
-  --dm-neutral-700: oklch(0.9 0.008 85);
-  --dm-neutral-800: oklch(0.95 0.006 85);
-  --dm-neutral-900: oklch(0.98 0.004 85);
-}
-
-/*
- * Dark-mode application — shared by the OS media query and the
- * `[data-theme="dark"]` JS toggle. Both reassign the scale custom properties
- * to the `--dm-*` dark values, so the two triggers can never drift apart.
- */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-navy-50: var(--dm-navy-50);
-    --color-navy-100: var(--dm-navy-100);
-    --color-navy-200: var(--dm-navy-200);
-    --color-navy-300: var(--dm-navy-300);
-    --color-navy-400: var(--dm-navy-400);
-    --color-navy-500: var(--dm-navy-500);
-    --color-navy-600: var(--dm-navy-600);
-    --color-navy-700: var(--dm-navy-700);
-    --color-navy-800: var(--dm-navy-800);
-    --color-navy-900: var(--dm-navy-900);
-    --color-navy-950: var(--dm-navy-950);
-
-    --color-gold-50: var(--dm-gold-50);
-    --color-gold-100: var(--dm-gold-100);
-    --color-gold-200: var(--dm-gold-200);
-    --color-gold-300: var(--dm-gold-300);
-    --color-gold-400: var(--dm-gold-400);
-    --color-gold-500: var(--dm-gold-500);
-    --color-gold-600: var(--dm-gold-600);
-    --color-gold-700: var(--dm-gold-700);
-    --color-gold-800: var(--dm-gold-800);
-    --color-gold-900: var(--dm-gold-900);
-
-    --color-neutral-50: var(--dm-neutral-50);
-    --color-neutral-100: var(--dm-neutral-100);
-    --color-neutral-200: var(--dm-neutral-200);
-    --color-neutral-300: var(--dm-neutral-300);
-    --color-neutral-400: var(--dm-neutral-400);
-    --color-neutral-500: var(--dm-neutral-500);
-    --color-neutral-600: var(--dm-neutral-600);
-    --color-neutral-700: var(--dm-neutral-700);
-    --color-neutral-800: var(--dm-neutral-800);
-    --color-neutral-900: var(--dm-neutral-900);
-  }
-}
-
-/*
- * JS toggle override (isnad-graph / DS parity). `[data-theme="dark"]` forces
- * the dark scales regardless of OS preference; `[data-theme="light"]` forces
- * the light scales back. Because these are attribute selectors on <html> they
- * carry higher specificity than the `:root` media-query block above, so an
- * explicit toggle always wins over the OS default — matching the DS semantic
- * tokens' behavior and keeping brand + chrome in the same mode.
- */
-[data-theme="dark"] {
-  --color-navy-50: var(--dm-navy-50);
-  --color-navy-100: var(--dm-navy-100);
-  --color-navy-200: var(--dm-navy-200);
-  --color-navy-300: var(--dm-navy-300);
-  --color-navy-400: var(--dm-navy-400);
-  --color-navy-500: var(--dm-navy-500);
-  --color-navy-600: var(--dm-navy-600);
-  --color-navy-700: var(--dm-navy-700);
-  --color-navy-800: var(--dm-navy-800);
-  --color-navy-900: var(--dm-navy-900);
-  --color-navy-950: var(--dm-navy-950);
-
-  --color-gold-50: var(--dm-gold-50);
-  --color-gold-100: var(--dm-gold-100);
-  --color-gold-200: var(--dm-gold-200);
-  --color-gold-300: var(--dm-gold-300);
-  --color-gold-400: var(--dm-gold-400);
-  --color-gold-500: var(--dm-gold-500);
-  --color-gold-600: var(--dm-gold-600);
-  --color-gold-700: var(--dm-gold-700);
-  --color-gold-800: var(--dm-gold-800);
-  --color-gold-900: var(--dm-gold-900);
-
-  --color-neutral-50: var(--dm-neutral-50);
-  --color-neutral-100: var(--dm-neutral-100);
-  --color-neutral-200: var(--dm-neutral-200);
-  --color-neutral-300: var(--dm-neutral-300);
-  --color-neutral-400: var(--dm-neutral-400);
-  --color-neutral-500: var(--dm-neutral-500);
-  --color-neutral-600: var(--dm-neutral-600);
-  --color-neutral-700: var(--dm-neutral-700);
-  --color-neutral-800: var(--dm-neutral-800);
-  --color-neutral-900: var(--dm-neutral-900);
-}
-
-/*
- * `[data-theme="light"]` pins the LP scales to their light @theme values so an
- * explicit light toggle overrides a dark OS preference. (The @theme block at
- * the top already defines the light values on :root; this selector re-pins
- * them at attribute-selector specificity to beat the media query.)
- */
-[data-theme="light"] {
-  --color-navy-50: oklch(0.97 0.012 265);
-  --color-navy-100: oklch(0.92 0.022 265);
-  --color-navy-200: oklch(0.83 0.038 265);
-  --color-navy-300: oklch(0.72 0.055 265);
-  --color-navy-400: oklch(0.6 0.072 265);
-  --color-navy-500: var(--color-brand-navy, oklch(0.25 0.05 265));
-  --color-navy-600: oklch(0.4 0.058 265);
-  --color-navy-700: oklch(0.32 0.052 265);
-  --color-navy-800: oklch(0.24 0.045 265);
-  --color-navy-900: oklch(0.16 0.034 265);
-  --color-navy-950: oklch(0.1 0.024 265);
-
-  --color-gold-50: oklch(0.98 0.014 80);
-  --color-gold-100: oklch(0.95 0.034 80);
-  --color-gold-200: oklch(0.9 0.062 80);
-  --color-gold-300: oklch(0.84 0.09 80);
-  --color-gold-400: oklch(0.8 0.11 80);
-  --color-gold-500: var(--color-brand-gold, oklch(0.75 0.12 80));
-  --color-gold-600: oklch(0.65 0.118 80);
-  --color-gold-700: oklch(0.54 0.104 80);
-  --color-gold-800: oklch(0.43 0.084 80);
-  --color-gold-900: oklch(0.33 0.064 80);
-
-  --color-neutral-50: oklch(0.98 0.004 85);
-  --color-neutral-100: oklch(0.95 0.006 85);
-  --color-neutral-200: oklch(0.9 0.008 85);
-  --color-neutral-300: oklch(0.83 0.01 85);
-  --color-neutral-400: oklch(0.7 0.01 85);
-  --color-neutral-500: oklch(0.55 0.01 85);
-  --color-neutral-600: oklch(0.45 0.01 85);
-  --color-neutral-700: oklch(0.36 0.009 85);
-  --color-neutral-800: oklch(0.25 0.008 85);
-  --color-neutral-900: oklch(0.18 0.006 85);
-}
 
 /*
  * Shared primitives (#59)
@@ -292,20 +54,20 @@
   font-family: var(--font-body);
   font-weight: 600;
   font-size: 0.95rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   text-decoration: none;
 }
 
 .btn-primary {
-  background: var(--color-gold-500);
-  color: var(--color-navy-950);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
   transition:
     background-color 0.2s ease,
     transform 0.15s ease;
 }
 
 .btn-primary:hover {
-  background: var(--color-gold-400);
+  background: var(--color-primary-hover);
 }
 
 .btn-primary:active {
@@ -314,21 +76,21 @@
 
 .btn-secondary {
   background: transparent;
-  color: var(--color-neutral-100);
-  border: 1.5px solid var(--color-navy-300);
+  color: var(--color-foreground);
+  border: 1.5px solid var(--color-border);
   transition:
     border-color 0.2s ease,
     color 0.2s ease;
 }
 
 .btn-secondary:hover {
-  border-color: var(--color-gold-400);
-  color: var(--color-gold-300);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .btn-primary:focus-visible,
 .btn-secondary:focus-visible {
-  outline: 2px solid var(--color-gold-300);
+  outline: 2px solid var(--color-ring);
   outline-offset: 2px;
 }
 
@@ -345,7 +107,7 @@
 }
 
 .section-alt {
-  background: var(--color-neutral-50);
+  background: var(--color-muted);
 }
 
 .section-container {
@@ -357,7 +119,7 @@
   font-family: var(--font-heading);
   font-size: clamp(1.5rem, 3vw, 2.25rem);
   font-weight: 700;
-  color: var(--color-navy-800);
+  color: var(--color-foreground);
   text-align: center;
   margin-bottom: 3rem;
 }
@@ -366,7 +128,7 @@
   font-family: var(--font-body);
   font-size: 1.05rem;
   line-height: 1.8;
-  color: var(--color-neutral-700);
+  color: var(--color-muted-foreground);
   text-align: center;
   max-width: 48rem;
   margin: 0 auto 2.5rem;
@@ -382,7 +144,7 @@
   font-family: var(--font-heading);
   font-size: 1.1rem;
   font-weight: 700;
-  color: var(--color-navy-800);
+  color: var(--color-foreground);
   margin-bottom: 0.75rem;
 }
 
@@ -390,14 +152,14 @@
   font-family: var(--font-body);
   font-size: 0.925rem;
   line-height: 1.7;
-  color: var(--color-neutral-600);
+  color: var(--color-muted-foreground);
 }
 
 .card-surface {
   padding: 2rem;
-  background: var(--color-neutral-50);
-  border-radius: 0.75rem;
-  border: 1px solid var(--color-neutral-200);
+  background: var(--color-card);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
 }
 
 .card-center {


### PR DESCRIPTION
Closes #118

## What & why
The landing page was visually disjoint from the isnad-graph product ("really does not look good") because it shipped a **bespoke navy/gold/neutral OKLCH ladder** — a cool navy-hero + gold-accent marketing skin — while isnad-graph renders in the design system's **warm parchment / sienna / ink** semantic palette.

This PR removes the bespoke ladder and re-points every surface, text, and accent colour to the **design-system semantic tokens** — the exact tokens isnad-graph consumes in `frontend/src/styles/theme.css` (`--color-primary`, `--color-background`, `--color-foreground`, `--color-card`, `--color-muted`, `--color-border`, plus DS `--radius-*` / `--shadow-*`). One cohesive brand, all via the DS — the issue's hard constraint.

## Changes (7 files, +150 / −381)
- **`global.css`** — dropped the LP-local 11-step colour ladder and the ~150-line `--dm-*` dark-mode mirror; shared button/section/card primitives now reference DS semantic tokens and DS radii.
- **`index.astro`** — hero converted from a dark navy gradient to a light DS surface (`--color-background` → `--color-muted`); the geometric zellij accent is now sienna (`--color-primary`); pillars, stats, and the guiding-principle quote re-themed.
- **`PageLayout.astro`** — header + footer re-themed (light footer on `--color-muted`, links → `--color-primary` on hover); mobile menu uses `--color-card` / `--shadow-lg`.
- **`ProjectLayout.astro` / `about.astro` / `404.astro` / `BaseLayout.astro`** — prose, feature cards, CTA buttons, and the skip-link re-pointed to DS semantic tokens.

**Dark mode** now inherits directly from the DS tokens (`prefers-color-scheme` + the `[data-theme]` JS toggle) — no LP-side machinery to keep in sync.

## Hard-constraint compliance (all via the design system)
Every consumed token already exists in the published DS dist (`@noorinalabs/design-system@0.0.4-wave10.0`) — I verified all 18 are shipped, so **no new DS primitives were required and no bespoke one-offs were added.**

## Verification
- `astro build` — clean (4 pages).
- `astro check` — **0 errors, 0 warnings** (27 hints all pre-existing: SEO `is:inline`, e2e unused vars).
- `eslint` — clean; `src/**` is Prettier-clean.
- Built CSS: **zero** `navy/gold/neutral` references; resolves every DS semantic token including dark-mode variants (e.g. `--color-primary: oklch(.55 .14 45)` light / `oklch(.65 .14 45)` dark).

### Needs a visual check (could not run in sandbox)
No browser was available in the build environment, so a side-by-side visual diff vs. isnad-graph is still pending. The token-level and build-output evidence is strong, but a reviewer/owner eyeballing the rendered light hero, footer, and dark-mode flip would close the loop on the "visually consistent (side-by-side)" acceptance box.

### Pre-existing, out of scope (flagging, not fixing)
`npm run lint` runs `prettier --check .` over the whole repo and reports 5 unformatted **non-src** files (`.cspell.json`, `.markdownlint-cli2.jsonc`, `RUNBOOK.md`, `docs/branch-protection.md`, `.github/branch-protection/SPEC.md`). I confirmed all 5 are already unformatted on the base branch (`deployments/phase-4/wave-3`) and untouched by this PR — pre-existing debt, kept out of this scoped change.

One non-token leftover: `BaseLayout.astro` still has `<link rel="mask-icon" color="#16213e">` (a static Safari pinned-tab brand-mark colour tied to `favicon.svg`, not a CSS-themeable surface) — left as-is.

## Reviewers
@Cédric Novák (primary), @Marcia Vasquez-Paredes (secondary)
