### PR TITLE
fix(theme): set data-theme on <html> so DS semantic tokens resolve (#128)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -61,8 +61,36 @@ const resolvedOgImage = ogImage.startsWith("http")
 ---
 
 <!doctype html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" data-theme="light">
   <head>
+    <!--
+      Theme init (#128) — resolve data-theme on <html> before first paint.
+      The design system ships its base colour tokens only inside a Tailwind v4
+      `@theme {}` block, which the browser ignores when the dist is imported as
+      plain CSS (BaseLayout's `@noorinalabs/design-system/styles.css` import);
+      the DS's real token values live under `[data-theme="light"|"dark"]`.
+      Without this attribute every `--color-*` var is unresolved and the page
+      renders unstyled. This honours a stored choice (the future toggle, #116)
+      then the OS preference; the server-rendered `data-theme="light"` above is
+      the no-JS fallback. The durable fix is DS-side (emit tokens to `:root`).
+    -->
+    <script is:inline>
+      (() => {
+        try {
+          const stored = localStorage.getItem("theme");
+          const theme =
+            stored === "light" || stored === "dark"
+              ? stored
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+          document.documentElement.dataset.theme = theme;
+        } catch {
+          /* localStorage / matchMedia unavailable — keep the SSR light default */
+        }
+      })();
+    </script>
+
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,6 +64,17 @@ const resolvedOgImage = ogImage.startsWith("http")
 <html lang="en" dir="ltr" data-theme="light">
   <head>
     <!--
+      charset MUST stay within the first 1024 bytes of the document so the
+      browser's encoding prescan finds it (nginx sets no charset header, so this
+      meta is the only encoding signal). Keep it — and viewport — as the first
+      children of <head>, ahead of the theme block below; otherwise multibyte
+      content (e.g. "Çelik" on /team) mojibakes. The theme init does not depend
+      on coming first — the charset prescan is independent of script position.
+    -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!--
       Theme init (#128) — resolve data-theme on <html> before first paint.
       The design system ships its base colour tokens only inside a Tailwind v4
       `@theme {}` block, which the browser ignores when the dist is imported as
@@ -90,9 +101,6 @@ const resolvedOgImage = ogImage.startsWith("http")
         }
       })();
     </script>
-
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <title>{title} | Noorina Labs</title>
     <meta name="description" content={description} />

--- a/tests/unit/layouts.test.ts
+++ b/tests/unit/layouts.test.ts
@@ -13,7 +13,9 @@ describe("BaseLayout", () => {
 
   it("renders valid HTML5 document", () => {
     expect(html).toContain("<!DOCTYPE html>");
-    expect(html).toContain('<html lang="en" dir="ltr">');
+    // data-theme is the server-rendered no-JS default (#128); the pre-paint
+    // init script may upgrade it to the OS/stored preference at runtime.
+    expect(html).toContain('<html lang="en" dir="ltr" data-theme="light">');
     expect(html).toContain('<meta charset="utf-8">');
     expect(html).toContain("viewport");
   });


### PR DESCRIPTION
Closes #128

## The bug
#125 re-pointed the landing page onto the design-system semantic tokens, but the DS dist defines its **base** token values only inside a Tailwind v4 `@theme {}` block. Imported as plain CSS (BaseLayout's `@noorinalabs/design-system/styles.css` import), the browser ignores `@theme {}` as an unknown at-rule, so the only browser-honoured token definitions are the `[data-theme="light"|"dark"]` blocks. **Nothing set `data-theme` on `<html>`**, so every `var(--color-*)` resolved empty at runtime — borders, backgrounds, and theme colours rendered unstyled on every page, in dev and build, light and dark. (Caught by the lp#113/#124 `.feature-card` border regression test — the first to assert a token-*resolution*-dependent computed style.)

## The fix (LP-side stopgap)
Set `data-theme` on `<html>` in `BaseLayout.astro`:
- server-rendered `data-theme="light"` — no-JS fallback;
- a pre-paint `is:inline` init script that upgrades to a stored choice (future #116 toggle) or the OS `prefers-color-scheme`, before first paint (no FOUC).

This makes the DS's `[data-theme]` token blocks apply. It delivers the "pre-paint init" piece of #116; #116's user-facing toggle UI + persistence remain separate enhancement scope.

The **durable** fix is DS-side (the published dist should compile `@theme` → `:root` so the default light theme works with zero consumer machinery) — tracked separately in design-system.

## Verification (live, on the built site)
| | before | after |
|---|---|---|
| `--color-primary` (light) | `""` (empty) | `oklch(.55 .14 45)` |
| `--color-border` (light) | `""` | `oklch(.85 .01 85)` |
| `.feature-card` border | `none` | `solid` |
| dark mode (`prefers-color-scheme: dark`) | tokens empty | `data-theme=dark`, tokens resolve |

- `npm run build` clean; `npx astro check`/eslint/prettier clean.
- **72 unit tests pass** (updated the BaseLayout HTML-shell assertion for the new attribute); **14 e2e pass** incl. axe a11y on all pages now rendering with real colours.

Reviewers: @Kofi Mensah-Williams + @Cédric.
