### PR TITLE
fix(team): re-tint placeholder monogram to the DS warm palette (#127)

### DIFF
--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -17,9 +17,15 @@ const description =
   "Meet the people behind Noorina Labs — the team building open tools for Islamic scholarly research.";
 
 /**
- * Build an inline SVG monogram avatar (navy field, gold ring, member initials)
- * as a data URI, so each member has a tasteful placeholder portrait with no
- * binary assets to manage. Returns a string usable as an <img> src.
+ * Build an inline SVG monogram avatar (sienna field, parchment ring, white
+ * member initials) as a data URI, so each member has a tasteful placeholder
+ * portrait with no binary assets to manage. Returns a string usable as an
+ * <img> src.
+ *
+ * Colours are literal sRGB approximations of the design-system warm palette
+ * (a data-URI SVG can't reference CSS tokens — same constrained class as the
+ * favicon mask-icon), keeping the monogram cohesive with the team page's
+ * sienna/parchment/ink surface (#127). White-on-sienna initials clear WCAG AA.
  */
 function avatarFor(name: string): string {
   const initials = name
@@ -32,9 +38,9 @@ function avatarFor(name: string): string {
     .join("");
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img">
-  <rect width="160" height="160" fill="#1a2347"/>
-  <circle cx="80" cy="80" r="62" fill="none" stroke="#d4a22e" stroke-width="3"/>
-  <text x="80" y="80" fill="#faf0d5" font-family="Georgia, 'IBM Plex Serif', serif" font-size="56" font-weight="700" text-anchor="middle" dominant-baseline="central">${initials}</text>
+  <rect width="160" height="160" fill="#a86a3a"/>
+  <circle cx="80" cy="80" r="62" fill="none" stroke="#f4f0e7" stroke-width="3"/>
+  <text x="80" y="80" fill="#ffffff" font-family="Georgia, 'IBM Plex Serif', serif" font-size="56" font-weight="700" text-anchor="middle" dominant-baseline="central">${initials}</text>
 </svg>`;
 
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;


### PR DESCRIPTION
Closes #127

## What
Re-tint the team-page placeholder monogram (data-URI SVG, shown when a member has no `photo`) from the old brand palette to the design-system warm palette, so it's cohesive with the now-sienna/parchment team surface (the disjoint lp#119 closes). Per Kofi's spec on #123.

A data-URI SVG can't reference CSS tokens (must be literal hex — same constrained class as the favicon mask-icon), so this is a literal-hex swap, not a token migration:

| element | before | after |
|---|---|---|
| field (`<rect>`) | `#1a2347` navy | `#a86a3a` sienna |
| ring (`<circle stroke>`) | `#d4a22e` gold | `#f4f0e7` parchment |
| initials (`<text>`) | `#faf0d5` cream | `#ffffff` white |

(Also updated the `avatarFor` docstring to describe the new palette.)

## Verification
- White-on-sienna initials measure **4.39:1** — clears WCAG **AA for large text** (the initials are 56px bold; large-text threshold is 3:1). The applicable level given the glyph size.
- `npm run build` clean; eslint + prettier clean.
- e2e a11y green — all 5 pass incl. "team page has no critical a11y violations" and "images have alt text".
- Built `/team` contains the new `#a86a3a` / `#f4f0e7` literals.
- Scope: monogram SVG literals + its docstring only; no token or structure change.

Reviewers: @Cédric + @Nazia Rahman.
