### PR TITLE
feat: reactivity + parallax motion via design system (#121)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/ibm-plex-sans": "^5.2.8",
         "@fontsource/ibm-plex-serif": "^5.2.7",
         "@fontsource/noto-naskh-arabic": "^5.2.11",
-        "@noorinalabs/design-system": "^0.0.4-wave10.0",
+        "@noorinalabs/design-system": "^0.0.5-wave4.0",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
         "tailwindcss": "^4.2.2"
@@ -1578,10 +1578,9 @@
       }
     },
     "node_modules/@noorinalabs/design-system": {
-      "version": "0.0.4-wave10.0",
-      "resolved": "https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.4-wave10.0/3afa45e7c68364a657aecfc05adb2d0a284fcce5",
-      "integrity": "sha512-W9BKg/rXr5eCEUIQ5iaVbmOjTkDEdsn3XCnBddLuDCs6OF+Zzi/Bgs4ZKb94X1YV4XCjU7YHDSDsugXZXmq3wQ==",
-      "license": "Apache-2.0",
+      "version": "0.0.5-wave4.0",
+      "resolved": "https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.5-wave4.0/5aa60b1234f7579f791eddd4b77781734fe321f7",
+      "integrity": "sha512-pJt/qeyWmMOFlksMRXBY0IEiKOhWq2kMg4fA6xr6R7tIj6f5h55DL+7a2eKcb7RMytIGCjqVHveclNppTzasUQ==",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@fontsource/ibm-plex-sans": "^5.2.8",
     "@fontsource/ibm-plex-serif": "^5.2.7",
     "@fontsource/noto-naskh-arabic": "^5.2.11",
-    "@noorinalabs/design-system": "^0.0.4-wave10.0",
+    "@noorinalabs/design-system": "^0.0.5-wave4.0",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
     "tailwindcss": "^4.2.2"

--- a/src/components/ScrollReveal.astro
+++ b/src/components/ScrollReveal.astro
@@ -1,0 +1,35 @@
+---
+/**
+ * ScrollReveal — wraps content so it fades + rises into view on scroll.
+ *
+ * A thin convenience wrapper over the motion primitives in
+ * src/styles/motion.css (which are built on the design system's motion tokens).
+ * The wrapped element renders fully visible with JS disabled or when the user
+ * prefers reduced motion — the hidden pre-reveal state is gated on
+ * `html.motion-ready`, set by src/scripts/motion.ts only when motion is allowed.
+ *
+ * The underlying primitive is the `.reveal` class + `data-reveal` attribute, so
+ * elements that cannot take an extra wrapper (e.g. CSS-grid children) can opt in
+ * directly with `class="… reveal" data-reveal` instead of using this component.
+ *
+ * Props:
+ *   as     — wrapper tag (default `div`)
+ *   delay  — stagger step 1–3 (maps to DS --duration-fast/normal/slow); 0 = none
+ *   class  — extra classes forwarded to the wrapper
+ */
+interface Props {
+  as?: keyof HTMLElementTagNameMap;
+  delay?: 0 | 1 | 2 | 3;
+  class?: string;
+}
+
+const { as = "div", delay = 0, class: className } = Astro.props;
+const Tag = as;
+---
+
+<Tag
+  class:list={["reveal", delay > 0 && `reveal-delay-${delay}`, className]}
+  data-reveal
+>
+  <slot />
+</Tag>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,9 @@
  */
 import "@noorinalabs/design-system/styles.css";
 import "../styles/global.css";
+/* Motion primitives (#121) — scroll-reveal + parallax, built on the DS motion
+   tokens. Loaded after global.css; the runtime lives in src/scripts/motion.ts. */
+import "../styles/motion.css";
 
 /* Font loading (#99) — IBM Plex + Noto Naskh Arabic */
 import "@fontsource/ibm-plex-sans/400.css";
@@ -102,6 +105,30 @@ const resolvedOgImage = ogImage.startsWith("http")
       })();
     </script>
 
+    <!--
+      Motion gate (#121) — set `motion-ready` on <html> BEFORE first paint when
+      motion is allowed, so scroll-reveal elements start hidden without a
+      visible→hidden flash on the above-the-fold hero. Mirrors the theme-init
+      pattern above. The deferred runtime (src/scripts/motion.ts) re-applies the
+      same guard and is the behavioural authority (observers + parallax); this
+      inline pass only avoids the paint flash. With JS off or reduced-motion,
+      `motion-ready` is never added and all content stays visible (motion.css).
+    -->
+    <script is:inline>
+      (() => {
+        try {
+          if (
+            !window.matchMedia("(prefers-reduced-motion: reduce)").matches &&
+            "IntersectionObserver" in window
+          ) {
+            document.documentElement.classList.add("motion-ready");
+          }
+        } catch {
+          /* matchMedia unavailable — leave content visible (no motion-ready) */
+        }
+      })();
+    </script>
+
     <title>{title} | Noorina Labs</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonical} />
@@ -137,6 +164,16 @@ const resolvedOgImage = ogImage.startsWith("http")
 
     <!-- Slot for page-level scripts -->
     <slot name="scripts" />
+
+    <!--
+      Motion runtime (#121) — scroll-reveal + parallax. Bails immediately on
+      `prefers-reduced-motion: reduce` or missing APIs, leaving content visible.
+      See src/scripts/motion.ts and src/styles/motion.css.
+    -->
+    <script>
+      import { initMotion } from "../scripts/motion";
+      initMotion();
+    </script>
   </body>
 </html>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "../layouts/PageLayout.astro";
 import SEO from "../components/SEO.astro";
+import ScrollReveal from "../components/ScrollReveal.astro";
 ---
 
 <PageLayout
@@ -11,8 +12,14 @@ import SEO from "../components/SEO.astro";
 
   <!-- Hero -->
   <section class="hero" aria-labelledby="hero-heading">
-    <div class="hero-pattern" aria-hidden="true"></div>
-    <div class="hero-content">
+    <div
+      class="hero-pattern"
+      aria-hidden="true"
+      data-parallax
+      data-parallax-speed="0.18"
+    >
+    </div>
+    <div class="hero-content reveal" data-reveal>
       <h1 id="hero-heading" class="hero-title">
         Illuminating Fourteen Centuries<br />of Islamic Scholarship
       </h1>
@@ -41,7 +48,7 @@ import SEO from "../components/SEO.astro";
   <section class="section" aria-labelledby="principle-heading">
     <div class="section-container principle-container">
       <h2 id="principle-heading" class="sr-only">Guiding Principle</h2>
-      <blockquote class="principle-quote">
+      <blockquote class="principle-quote reveal" data-reveal>
         <p>
           Noorina Labs will never privilege one school of thought, one
           collection, or one interpretive tradition over another. Our platform
@@ -54,8 +61,10 @@ import SEO from "../components/SEO.astro";
   <!-- The Problem -->
   <section class="section section-alt" aria-labelledby="problem-heading">
     <div class="section-container">
-      <h2 id="problem-heading" class="section-title">The Problem</h2>
-      <p class="section-intro">
+      <h2 id="problem-heading" class="section-title reveal" data-reveal>
+        The Problem
+      </h2>
+      <p class="section-intro reveal reveal-delay-1" data-reveal>
         Despite fourteen centuries of meticulous scholarship and 1.9 billion
         Muslims worldwide, there are zero cross-tradition graph tools for
         studying hadith transmission. Existing digital resources remain siloed
@@ -85,15 +94,15 @@ import SEO from "../components/SEO.astro";
         </li>
       </ol>
       <div class="problem-stats">
-        <div class="stat">
+        <div class="stat reveal" data-reveal>
           <span class="stat-number">1.9B</span>
           <span class="stat-label">Muslims worldwide</span>
         </div>
-        <div class="stat">
+        <div class="stat reveal reveal-delay-1" data-reveal>
           <span class="stat-number">14+</span>
           <span class="stat-label">centuries of scholarship</span>
         </div>
-        <div class="stat">
+        <div class="stat reveal reveal-delay-2" data-reveal>
           <span class="stat-number">0</span>
           <span class="stat-label">cross-tradition graph tools</span>
         </div>
@@ -104,36 +113,38 @@ import SEO from "../components/SEO.astro";
   <!-- Isnad Graph Capabilities -->
   <section id="projects" class="section" aria-labelledby="capabilities-heading">
     <div class="section-container">
-      <h2 id="capabilities-heading" class="section-title">The Isnad Graph</h2>
-      <p class="section-intro">
+      <h2 id="capabilities-heading" class="section-title reveal" data-reveal>
+        The Isnad Graph
+      </h2>
+      <p class="section-intro reveal reveal-delay-1" data-reveal>
         A computational hadith analysis platform that maps chains of narration (<span
           lang="ar">أسانيد</span
         >) as an interactive, searchable graph. Our first product answers the
         questions that existing tools cannot.
       </p>
       <div class="capabilities-grid">
-        <div class="card card-surface">
+        <div class="card card-surface reveal" data-reveal>
           <h3>Cross-Collection Search</h3>
           <p>
             Search narrators and hadith across major Sunni and Shia collections
             simultaneously — no more switching between siloed databases.
           </p>
         </div>
-        <div class="card card-surface">
+        <div class="card card-surface reveal reveal-delay-1" data-reveal>
           <h3>Graph Explorer</h3>
           <p>
             Visualize narrator networks as an interactive graph. Zoom, filter,
             and trace transmission paths between any two narrators.
           </p>
         </div>
-        <div class="card card-surface">
+        <div class="card card-surface reveal reveal-delay-2" data-reveal>
           <h3>Cross-Tradition Comparison</h3>
           <p>
             Compare narrator assessments across Sunni and Shia traditions
             side-by-side. Discover shared narrators and divergent evaluations.
           </p>
         </div>
-        <div class="card card-surface">
+        <div class="card card-surface reveal" data-reveal>
           <h3>Historical Context</h3>
           <p>
             Biographical profiles with teacher-student relationships,
@@ -141,7 +152,7 @@ import SEO from "../components/SEO.astro";
             rijal literature.
           </p>
         </div>
-        <div class="card card-surface">
+        <div class="card card-surface reveal reveal-delay-1" data-reveal>
           <h3>Collection-Level Analysis</h3>
           <p>
             Understand the structure of individual hadith collections — most
@@ -149,20 +160,22 @@ import SEO from "../components/SEO.astro";
           </p>
         </div>
       </div>
-      <div class="section-cta">
+      <ScrollReveal class="section-cta" delay={1}>
         <a href="/projects/isnad-graph" class="btn-primary">
           Explore the Isnad Graph
         </a>
-      </div>
+      </ScrollReveal>
     </div>
   </section>
 
   <!-- Why Now -->
   <section class="section section-alt" aria-labelledby="why-now-heading">
     <div class="section-container">
-      <h2 id="why-now-heading" class="section-title">Why Now</h2>
+      <h2 id="why-now-heading" class="section-title reveal" data-reveal>
+        Why Now
+      </h2>
       <div class="why-now-grid">
-        <div class="card card-center">
+        <div class="card card-center reveal" data-reveal>
           <h3>Computational tools have matured</h3>
           <p>
             Graph databases, network analysis, and natural language processing
@@ -170,7 +183,7 @@ import SEO from "../components/SEO.astro";
             replace — hadith scholarship.
           </p>
         </div>
-        <div class="card card-center">
+        <div class="card card-center reveal reveal-delay-1" data-reveal>
           <h3>Open data is available</h3>
           <p>
             Digitized hadith collections and biographical dictionaries are now
@@ -178,7 +191,7 @@ import SEO from "../components/SEO.astro";
             possible for the first time.
           </p>
         </div>
-        <div class="card card-center">
+        <div class="card card-center reveal reveal-delay-2" data-reveal>
           <h3>Institutional appetite is growing</h3>
           <p>
             Universities, research centers, and Islamic institutions are
@@ -193,16 +206,16 @@ import SEO from "../components/SEO.astro";
   <!-- Partnership & Support -->
   <section class="section" aria-labelledby="partnership-heading">
     <div class="section-container">
-      <h2 id="partnership-heading" class="section-title">
+      <h2 id="partnership-heading" class="section-title reveal" data-reveal>
         Partnership & Support
       </h2>
-      <p class="section-intro">
+      <p class="section-intro reveal reveal-delay-1" data-reveal>
         Noorina Labs is building infrastructure for the next generation of
         Islamic scholarly research. We work with institutions, researchers, and
         funders who share our commitment to open, rigorous, and inclusive tools.
       </p>
       <div class="partnership-grid">
-        <div class="card card-surface">
+        <div class="card card-surface reveal" data-reveal>
           <h3>Research Partnership</h3>
           <p>
             Collaborate on data curation, scholarly review, and new analytical
@@ -210,7 +223,7 @@ import SEO from "../components/SEO.astro";
             meets the standards of the tradition.
           </p>
         </div>
-        <div class="card card-surface">
+        <div class="card card-surface reveal reveal-delay-1" data-reveal>
           <h3>Institutional License</h3>
           <p>
             Integrate the Isnad Graph into your university or research center.
@@ -218,7 +231,7 @@ import SEO from "../components/SEO.astro";
             available for academic institutions.
           </p>
         </div>
-        <div class="card card-surface">
+        <div class="card card-surface reveal reveal-delay-2" data-reveal>
           <h3>Grant & Philanthropic</h3>
           <p>
             Support open-source infrastructure for Islamic scholarship. Grants
@@ -233,14 +246,18 @@ import SEO from "../components/SEO.astro";
   <!-- Contact -->
   <section class="section section-alt" aria-labelledby="contact-heading">
     <div class="section-container contact-container">
-      <h2 id="contact-heading" class="section-title">Get in Touch</h2>
-      <p class="section-intro">
+      <h2 id="contact-heading" class="section-title reveal" data-reveal>
+        Get in Touch
+      </h2>
+      <p class="section-intro reveal reveal-delay-1" data-reveal>
         Whether you are a researcher, institution, funder, or curious learner,
         we would love to hear from you.
       </p>
-      <a href="mailto:info@noorinalabs.com" class="btn-primary">
-        info@noorinalabs.com
-      </a>
+      <ScrollReveal as="div" delay={2}>
+        <a href="mailto:info@noorinalabs.com" class="btn-primary">
+          info@noorinalabs.com
+        </a>
+      </ScrollReveal>
     </div>
   </section>
 </PageLayout>
@@ -272,7 +289,13 @@ import SEO from "../components/SEO.astro";
    */
   .hero-pattern {
     position: absolute;
-    inset: 0;
+    /*
+     * Extra bleed below the hero so the parallax drift (the layer translates
+     * up to ~18% of scroll via [data-parallax]) never exposes a gap at the
+     * bottom edge — the hero clips the overflow. With motion disabled the
+     * extra height is simply clipped and invisible.
+     */
+    inset: 0 0 -30% 0;
     opacity: 0.05;
     background-image:
       linear-gradient(

--- a/src/scripts/motion.ts
+++ b/src/scripts/motion.ts
@@ -1,0 +1,96 @@
+/*
+ * Motion runtime (#121)
+ * =====================
+ * Drives the scroll-reveal + parallax primitives defined in
+ * src/styles/motion.css. The CSS does all the visual work (and consumes the
+ * design system's motion tokens); this module only toggles state.
+ *
+ * Reduced-motion first: if the user prefers reduced motion, OR the required
+ * browser APIs are missing, we bail immediately and never add `.motion-ready`,
+ * so every `.reveal` element stays in its visible final state and no scroll
+ * listener is attached.
+ */
+
+/** Wire up scroll-reveal + parallax. Safe to call once per page load. */
+export function initMotion(): void {
+  const root = document.documentElement;
+
+  const prefersReducedMotion =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  if (prefersReducedMotion || typeof IntersectionObserver === "undefined") {
+    // Leave content visible; no motion-ready class, no observers/listeners.
+    return;
+  }
+
+  // Tells motion.css to apply the pre-reveal hidden state + parallax transforms.
+  root.classList.add("motion-ready");
+
+  initScrollReveal();
+  initParallax();
+}
+
+/** Reveal each `[data-reveal]` element once, the first time it enters view. */
+function initScrollReveal(): void {
+  const targets = document.querySelectorAll<HTMLElement>("[data-reveal]");
+  if (targets.length === 0) return;
+
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("is-visible");
+          obs.unobserve(entry.target); // reveal once, then stop watching
+        }
+      }
+    },
+    // Trigger a touch before the element is fully in view for a natural feel.
+    { rootMargin: "0px 0px -10% 0px", threshold: 0.1 },
+  );
+
+  for (const el of targets) observer.observe(el);
+}
+
+/**
+ * Drift each `[data-parallax]` layer at a fraction of scroll. `data-parallax-speed`
+ * (0–1, default 0.2) controls subtlety; smaller is gentler. Updates are
+ * batched into a single rAF per scroll burst and only ever touch `transform`
+ * (via a CSS custom property), so the work stays off the main layout path.
+ */
+function initParallax(): void {
+  const layers = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-parallax]"),
+  );
+  if (layers.length === 0) return;
+
+  const speeds = layers.map((el) => {
+    const raw = Number.parseFloat(el.dataset.parallaxSpeed ?? "");
+    return Number.isFinite(raw) ? raw : 0.2;
+  });
+
+  let ticking = false;
+
+  const update = (): void => {
+    const y = window.scrollY;
+    for (let i = 0; i < layers.length; i++) {
+      // Negative offset: the layer recedes (moves slower than the page).
+      const offset = -(y * speeds[i]);
+      layers[i].style.setProperty(
+        "--parallax-offset",
+        `${offset.toFixed(1)}px`,
+      );
+    }
+    ticking = false;
+  };
+
+  const onScroll = (): void => {
+    if (!ticking) {
+      ticking = true;
+      window.requestAnimationFrame(update);
+    }
+  };
+
+  update(); // set initial offsets (handles a non-zero scroll on load)
+  window.addEventListener("scroll", onScroll, { passive: true });
+}

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -1,0 +1,89 @@
+/*
+ * Motion primitives (#121)
+ * ========================
+ * Scroll-reveal + parallax utilities for the landing page, built entirely on
+ * the design system's MOTION TOKENS (--duration-*, --ease-*). The DS compiles
+ * those tokens to :root in its dist (DS #104), which BaseLayout pulls in via
+ * `@noorinalabs/design-system/styles.css`. No bespoke easing curves or
+ * durations live here — every timing value resolves to a DS token, per the
+ * #121 hard constraint ("consume DS tokens; where the DS lacks something, add
+ * it to the DS first, then consume — no bespoke one-off styles").
+ *
+ * DS gap flagged for follow-up: the design system ships motion *tokens* but not
+ * the scroll-reveal / parallax *primitives* (the utility classes + the
+ * IntersectionObserver / scroll mechanism). Until those land in the DS as
+ * framework-neutral CSS — so the React isnad-graph app can reuse the very same
+ * primitives — the landing page defines the consumption layer here against the
+ * DS tokens. Promoting these classes into the DS is the #121 acceptance item
+ * "reusable motion primitives landed in the design system" and is tracked as a
+ * DS follow-up.
+ *
+ * Accessibility / no-JS safety:
+ *   - Content is fully visible by DEFAULT. The hidden pre-reveal state applies
+ *     ONLY under `html.motion-ready` — a class src/scripts/motion.ts adds after
+ *     it confirms motion is allowed and supported. So with JS disabled, or when
+ *     the script bails on `prefers-reduced-motion: reduce`, every `.reveal`
+ *     element renders in its final, visible state with no transition.
+ *   - The `prefers-reduced-motion: reduce` block is a belt-and-braces guard for
+ *     the case where `.motion-ready` is ever present: it forces the visible
+ *     state and removes transitions / parallax transforms.
+ */
+
+/* ============================================================
+ * SCROLL-REVEAL — fade + rise as the element enters the viewport
+ * ============================================================ */
+
+/* Default (no-JS / reduced-motion / pre-script): fully visible, no transform. */
+.reveal {
+  opacity: 1;
+  transform: none;
+}
+
+html.motion-ready .reveal {
+  opacity: 0;
+  transform: translateY(1.5rem);
+  transition:
+    opacity var(--duration-slower) var(--ease-out),
+    transform var(--duration-slower) var(--ease-out);
+}
+
+html.motion-ready .reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* Stagger helpers — small, DS-token-derived delays for grouped reveals. */
+html.motion-ready .reveal-delay-1 {
+  transition-delay: var(--duration-fast);
+}
+html.motion-ready .reveal-delay-2 {
+  transition-delay: var(--duration-normal);
+}
+html.motion-ready .reveal-delay-3 {
+  transition-delay: var(--duration-slow);
+}
+
+/* ============================================================
+ * PARALLAX — decorative layers drift at a fraction of scroll
+ * src/scripts/motion.ts sets `--parallax-offset` (px) per element on scroll
+ * (rAF-throttled). The transform stays GPU-friendly (translate3d only) and the
+ * rule is inert until the script upgrades <html> to `.motion-ready`.
+ * ============================================================ */
+html.motion-ready [data-parallax] {
+  transform: translate3d(0, var(--parallax-offset, 0), 0);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  html.motion-ready .reveal,
+  html.motion-ready .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  html.motion-ready [data-parallax] {
+    transform: none;
+  }
+}

--- a/tests/unit/motion.test.ts
+++ b/tests/unit/motion.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { initMotion } from "../../src/scripts/motion";
+
+const distDir = resolve(import.meta.dirname, "../../dist");
+
+function readPage(path: string): string {
+  return readFileSync(resolve(distDir, path), "utf-8");
+}
+
+describe("Homepage motion markup (#121)", () => {
+  const html = readPage("index.html");
+
+  it("marks the hero decorative layer as a parallax target", () => {
+    expect(html).toContain("data-parallax");
+    expect(html).toContain('data-parallax-speed="0.18"');
+  });
+
+  it("opts page sections/cards into scroll-reveal", () => {
+    const count = (html.match(/data-reveal/g) ?? []).length;
+    // Hero + section titles/intros + cards + stats — a generous lower bound.
+    expect(count).toBeGreaterThanOrEqual(8);
+  });
+
+  it("emits the reveal class so content is visible by default (gated by motion-ready)", () => {
+    expect(html).toMatch(/class="[^"]*\breveal\b[^"]*"/);
+  });
+});
+
+describe("initMotion reduced-motion guard (#121)", () => {
+  beforeEach(() => {
+    document.documentElement.className = "";
+    // happy-dom lacks IntersectionObserver — stub a no-op so the non-reduced
+    // path doesn't bail on the missing-API check.
+    (
+      globalThis as unknown as { IntersectionObserver: unknown }
+    ).IntersectionObserver = class {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+  });
+
+  function mockReducedMotion(reduce: boolean): void {
+    window.matchMedia = ((query: string) => ({
+      matches: reduce && query.includes("reduce"),
+      media: query,
+      onchange: null,
+      addEventListener(): void {},
+      removeEventListener(): void {},
+      addListener(): void {},
+      removeListener(): void {},
+      dispatchEvent(): boolean {
+        return false;
+      },
+    })) as typeof window.matchMedia;
+  }
+
+  it("does NOT add motion-ready when the user prefers reduced motion", () => {
+    mockReducedMotion(true);
+    initMotion();
+    expect(document.documentElement.classList.contains("motion-ready")).toBe(
+      false,
+    );
+  });
+
+  it("adds motion-ready when motion is allowed", () => {
+    mockReducedMotion(false);
+    initMotion();
+    expect(document.documentElement.classList.contains("motion-ready")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Closes #121

## What

Adds tasteful **reactivity + parallax scrolling** to the landing page, built **entirely on the design system's motion tokens** — no bespoke easing curves or durations.

## DS dependency

Bumped `@noorinalabs/design-system` `^0.0.4-wave10.0` → **`^0.0.5-wave4.0`** (+ lockfile). That version compiles the DS motion tokens to `:root` (DS #104) so the Astro LP can consume them as plain CSS vars:
`--duration-fast|normal|slow|slower`, `--ease-default|in|out|in-out`.

## Motion approach (what DS surface I consumed)

- **DS motion TOKENS** drive every transition/animation timing — `var(--ease-out)`, `var(--duration-slower)`, etc. No magic numbers.
- **`src/styles/motion.css`** — the reusable primitives: `.reveal` (fade + rise) and `[data-parallax]` (translate3d drift). The pre-reveal hidden state is gated on `html.motion-ready`, so:
  - JS off → content fully visible (no-JS safe).
  - `prefers-reduced-motion: reduce` → forced visible, transitions/parallax removed.
- **`src/scripts/motion.ts`** — `IntersectionObserver` reveal (once per element) + rAF-throttled, transform-only parallax (GPU-friendly, passive scroll listener). Bails immediately on reduced-motion / missing APIs.
- **`src/components/ScrollReveal.astro`** — convenience wrapper over the primitive (grid children opt in via the raw `.reveal`/`data-reveal` to avoid breaking CSS grid).
- **BaseLayout** — imports `motion.css`, wires the runtime, and adds a **pre-paint inline gate** that sets `motion-ready` before first paint (mirrors the existing theme-init pattern) to avoid an above-the-fold reveal flash.
- **index.astro** — hero decorative-pattern parallax (`data-parallax-speed="0.18"`) + staggered scroll-reveals across the hero, section titles/intros, capability/why-now/partnership cards, and stats.

## Reduced-motion / a11y

`prefers-reduced-motion: reduce` is honoured at three layers: the pre-paint gate never adds `motion-ready`, `initMotion()` bails, and `motion.css` has a belt-and-braces `@media (prefers-reduced-motion: reduce)` block. Content is visible by default in every degraded path.

## DS-consumability gap flagged (needs a DS follow-up)

DS 0.0.5-wave4.0 ships motion **tokens** but NOT the scroll-reveal / parallax **primitives** themselves (the utility classes + observer/scroll mechanism). Per the brief, I did **not** hand-roll a parallel token system — I consumed the DS tokens and built the consumption layer in the LP. The #121 acceptance item **"reusable motion primitives landed in the design system"** is only partially met (tokens yes, reveal/parallax classes no). Promoting `.reveal` + `[data-parallax]` into the DS as framework-neutral CSS — so the React isnad-graph app can reuse the same primitives — should be a DS follow-up issue. Flagging for the team-lead to file/route.

## Test Plan

- [x] `npm run build` — 4 pages built clean
- [x] `npx astro check` — 0 errors
- [x] `npx eslint .` — clean
- [x] `npx prettier --check "src/**/*.{ts,tsx,astro,css,md,json}"` (CI scope) — clean
- [x] `npm test` — 77 passed (incl. new `motion.test.ts`: parallax/reveal markup + reduced-motion guard behaviour)
- [ ] e2e (Playwright) runs in CI — `toBeVisible()` ignores `opacity`, so opacity:0 reveal elements remain "visible"; no expected regressions.

Note: the repo-root `npm run lint` script uses whole-repo `prettier --check .` and flags 5 pre-existing repo-root files (RUNBOOK.md, .cspell.json, docs/…, etc.) — pre-existing drift, outside CI's `src/**` prettier scope and not touched here.

Reviewers: @Cédric Novák (primary), @Marcia Vasquez-Paredes (secondary)
