### PR TITLE
fix: landing-page app links → isnad.noorinalabs.com (was isnad-graph.*)

### DIFF
--- a/src/content/projects/isnad-graph.mdx
+++ b/src/content/projects/isnad-graph.mdx
@@ -22,7 +22,7 @@ features:
     icon: "book"
 cta:
   label: "Explore the Isnad Graph"
-  href: "https://isnad-graph.noorinalabs.com"
+  href: "https://isnad.noorinalabs.com"
 publishDate: 2026-04-05
 ---
 

--- a/src/content/routes.md
+++ b/src/content/routes.md
@@ -59,7 +59,7 @@ BaseLayout.astro
 **Projects column:**
 | Label | Href | Notes |
 |-------|------|-------|
-| Isnad Graph | `https://isnad-graph.noorinalabs.com` | The live product (app) |
+| Isnad Graph | `https://isnad.noorinalabs.com` | The live product (app) |
 | About the Isnad Graph | `/projects/isnad-graph` | The project feature page on this site |
 
 **Organization column:**

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -32,7 +32,7 @@ const headerNav = [
 
 const footerNav = {
   projects: [
-    { label: "Isnad Graph", href: "https://isnad-graph.noorinalabs.com" },
+    { label: "Isnad Graph", href: "https://isnad.noorinalabs.com" },
     { label: "About the Isnad Graph", href: "/projects/isnad-graph" },
   ],
   organization: [


### PR DESCRIPTION
## What
Point the landing-page's external app links from the old domain `https://isnad-graph.noorinalabs.com` to `https://isnad.noorinalabs.com` (the `isnad.*` vhost the app is actually served from — isnad-graph→isnad rename, cf. deploy#449).

## Changed (3 external references)
- `src/content/projects/isnad-graph.mdx` — the "Explore the Isnad Graph" CTA href
- `src/layouts/PageLayout.astro` — top-nav "Isnad Graph" link
- `src/content/routes.md` — the routes doc "live product (app)" URL

## Unchanged (intentional)
Internal `/projects/isnad-graph` route slugs (homepage buttons, content slug, file names) — internal identifiers, not the app domain.

## Verification
Grep confirms zero remaining `isnad-graph.noorinalabs.com` and internal slugs intact; Astro build runs in CI.

Closes #134
