### PR TITLE
fix(lp#136): environment-aware isnad-graph links (runtime hostname derivation)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -174,6 +174,24 @@ const resolvedOgImage = ogImage.startsWith("http")
       import { initMotion } from "../scripts/motion";
       initMotion();
     </script>
+
+    <!--
+      Isnad app URL rewrite (#136) — runtime hostname derivation.
+      Static HTML renders the prod URL (https://isnad.noorinalabs.com) as the
+      href for all [data-isnad-app] links. This is correct for production, no-JS
+      visitors, and crawlers. On staging (stg.noorinalabs.com) the same Docker
+      image is promoted without a rebuild, so the prod URL is wrong; this script
+      rewrites those links to the staging isnad URL at runtime.
+    -->
+    <script>
+      import { isnadAppUrlFromHostname } from "../lib/isnad";
+      const resolved = isnadAppUrlFromHostname(window.location.hostname);
+      document
+        .querySelectorAll<HTMLAnchorElement>("[data-isnad-app]")
+        .forEach((el) => {
+          el.href = resolved;
+        });
+    </script>
   </body>
 </html>
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,6 +10,7 @@
  * Used by: Homepage (/), The Team (/team), and any general page.
  */
 import BaseLayout from "./BaseLayout.astro";
+import { PROD_ISNAD_URL } from "../lib/isnad";
 
 interface Props {
   title: string;
@@ -32,7 +33,8 @@ const headerNav = [
 
 const footerNav = {
   projects: [
-    { label: "Isnad Graph", href: "https://isnad.noorinalabs.com" },
+    /* isnadApp: true marks this link for runtime hostname rewrite (#136) */
+    { label: "Isnad Graph", href: PROD_ISNAD_URL, isnadApp: true },
     { label: "About the Isnad Graph", href: "/projects/isnad-graph" },
   ],
   organization: [
@@ -182,7 +184,12 @@ const footerNav = {
           {
             footerNav.projects.map((item) => (
               <li>
-                <a href={item.href}>{item.label}</a>
+                <a
+                  href={item.href}
+                  {...(item.isnadApp ? { "data-isnad-app": true } : {})}
+                >
+                  {item.label}
+                </a>
               </li>
             ))
           }

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -12,6 +12,7 @@
  */
 import PageLayout from "./PageLayout.astro";
 import Icon from "../components/Icon.astro";
+import { PROD_ISNAD_URL } from "../lib/isnad";
 
 interface Feature {
   title: string;
@@ -58,7 +59,12 @@ const {
 
     {
       cta && (
-        <a href={cta.href} class="cta-button">
+        /* data-isnad-app marks isnad-app links for runtime hostname rewrite (#136) */
+        <a
+          href={cta.href}
+          class="cta-button"
+          {...(cta.href === PROD_ISNAD_URL ? { "data-isnad-app": true } : {})}
+        >
           {cta.label}
         </a>
       )

--- a/src/lib/isnad.ts
+++ b/src/lib/isnad.ts
@@ -1,0 +1,37 @@
+/**
+ * Isnad app URL utilities (#136).
+ *
+ * The landing page is built-once-promoted: the same Docker image runs on staging
+ * and production. Build-time env vars cannot differentiate environments, so the
+ * correct isnad app URL must be derived at runtime from window.location.hostname.
+ *
+ * Derivation rule: isnad URL = "https://isnad." + hostname with leading "www."
+ * stripped. Falls back to PROD_ISNAD_URL for empty hostnames.
+ *
+ * Domain mapping (from deploy verify-deploy.yml + env/*.env):
+ *   prod: noorinalabs.com / www.noorinalabs.com → https://isnad.noorinalabs.com
+ *   stg:  stg.noorinalabs.com                  → https://isnad.stg.noorinalabs.com
+ */
+
+/** Production isnad app URL — used as the static-HTML default so the page is
+ *  correct for crawlers, no-JS users, and production visitors before the runtime
+ *  rewrite script fires. Staging is noindex (lp#63), so stg crawls don't matter. */
+export const PROD_ISNAD_URL = "https://isnad.noorinalabs.com";
+
+/**
+ * Derive the isnad app URL for a given hostname.
+ *
+ * @param hostname - e.g. window.location.hostname; empty string falls back to prod.
+ * @returns Absolute URL to the isnad app for that environment.
+ *
+ * @example
+ * isnadAppUrlFromHostname("noorinalabs.com")     // "https://isnad.noorinalabs.com"
+ * isnadAppUrlFromHostname("www.noorinalabs.com") // "https://isnad.noorinalabs.com"
+ * isnadAppUrlFromHostname("stg.noorinalabs.com") // "https://isnad.stg.noorinalabs.com"
+ * isnadAppUrlFromHostname("")                    // "https://isnad.noorinalabs.com"
+ */
+export function isnadAppUrlFromHostname(hostname: string): string {
+  if (!hostname) return PROD_ISNAD_URL;
+  const bare = hostname.replace(/^www\./, "");
+  return `https://isnad.${bare}`;
+}

--- a/tests/unit/isnad.test.ts
+++ b/tests/unit/isnad.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { PROD_ISNAD_URL, isnadAppUrlFromHostname } from "../../src/lib/isnad";
+
+describe("isnadAppUrlFromHostname", () => {
+  it("returns the prod isnad URL for noorinalabs.com", () => {
+    expect(isnadAppUrlFromHostname("noorinalabs.com")).toBe(
+      "https://isnad.noorinalabs.com",
+    );
+  });
+
+  it("strips a leading www. before constructing the URL", () => {
+    expect(isnadAppUrlFromHostname("www.noorinalabs.com")).toBe(
+      "https://isnad.noorinalabs.com",
+    );
+  });
+
+  it("returns the stg isnad URL for stg.noorinalabs.com", () => {
+    expect(isnadAppUrlFromHostname("stg.noorinalabs.com")).toBe(
+      "https://isnad.stg.noorinalabs.com",
+    );
+  });
+
+  it("falls back to PROD_ISNAD_URL for an empty hostname", () => {
+    expect(isnadAppUrlFromHostname("")).toBe(PROD_ISNAD_URL);
+  });
+
+  it("PROD_ISNAD_URL is the canonical production URL", () => {
+    expect(PROD_ISNAD_URL).toBe("https://isnad.noorinalabs.com");
+  });
+});


### PR DESCRIPTION
Closes #136

## Problem

The landing page is built-once-promoted: the same Docker image is tagged `stg-*` on push to main, then retagged `prod-*` via `promote.yml` — no rebuild. A build-time `PUBLIC_*` env var would bake the same URL into both environments. On staging, the hardcoded `https://isnad.noorinalabs.com` footer and CTA links point to production.

## Approach

Progressive enhancement — works for no-JS and crawlers:

1. **Centralised helper** `src/lib/isnad.ts` exports:
   - `PROD_ISNAD_URL = "https://isnad.noorinalabs.com"` — the static-HTML default
   - `isnadAppUrlFromHostname(hostname)` — derivation rule: strip leading `www.`, prepend `https://isnad.`
     - `stg.noorinalabs.com` → `https://isnad.stg.noorinalabs.com`
     - `noorinalabs.com` / `www.noorinalabs.com` → `https://isnad.noorinalabs.com`
     - empty hostname → `PROD_ISNAD_URL` (fallback)

2. **Static HTML** renders every isnad-app link with `href={PROD_ISNAD_URL}` and `data-isnad-app` marker. Prod and crawlers get the correct URL with no JS required.

3. **Runtime rewrite script** in `BaseLayout.astro` (same pattern as the motion runtime): on load, computes `isnadAppUrlFromHostname(window.location.hostname)` and rewrites all `[data-isnad-app]` hrefs.

4. **Unit tests** in `tests/unit/isnad.test.ts` cover the four specified cases.

## Files changed

| File | Change |
|------|--------|
| `src/lib/isnad.ts` | New — PROD_ISNAD_URL constant + isnadAppUrlFromHostname() |
| `src/layouts/BaseLayout.astro` | Add runtime rewrite `<script>` |
| `src/layouts/PageLayout.astro` | Import PROD_ISNAD_URL; add data-isnad-app to footer Isnad Graph anchor |
| `src/layouts/ProjectLayout.astro` | Import PROD_ISNAD_URL; add data-isnad-app to CTA anchor when href matches |
| `tests/unit/isnad.test.ts` | New — 5 unit tests for derivation function |

## Divergence from brief

- `about.mdx` does not exist in the current codebase — no isnad link to update there (the brief noted it as a possible third call site; it wasn't present).
- `src/content/projects/isnad-graph.mdx` CTA frontmatter keeps the literal string `"https://isnad.noorinalabs.com"` (MDX YAML frontmatter cannot import TS constants). The value equals `PROD_ISNAD_URL`; `ProjectLayout.astro` compares `cta.href === PROD_ISNAD_URL` to conditionally add `data-isnad-app`, so the rewrite fires correctly.

## Build & test

```
npm run build  → 4 pages built, no errors
npm run test   → 82 tests passed (7 test files, including 5 new isnad.test.ts tests)
```

Reviewers: @nazia-rahman @marcia-vasquez-paredes