### PR TITLE
fix(team): remove fabricated placeholder staff pre-launch (#138)

### DIFF
--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -5,6 +5,11 @@
  * member's name, title, or bio without touching page markup. To add or remove
  * a member, edit this list — the page renders one card per entry.
  *
+ * Pre-launch (#138): this list holds only real, consenting people. The earlier
+ * fabricated example members (an invented CTO, Head of Research, etc.) were
+ * removed so the launch never presents fictitious staff. Add real teammates
+ * here — with their consent — as confirmed bios become available.
+ *
  * Photos: every member currently uses a generated monogram placeholder (see
  * `avatarFor` in team.astro). When a real portrait is available, drop it in
  * `public/images/team/` and set the member's `photo` field to its path
@@ -27,35 +32,5 @@ export const team: TeamMember[] = [
     name: "Steven (Yusuf) French",
     title: "Executive Director",
     bio: "Yusuf founded Noorina Labs to build open, rigorous tools for the Islamic scholarly tradition. He sets the organisation's direction and stewards its commitment to scholarship-first, open-by-default work.",
-  },
-  {
-    name: "Dr. Amina Bello",
-    title: "Chief Technology Officer",
-    bio: "Amina leads engineering across the platform, from the graph database to the public web. She has spent her career building reliable systems for research data and cares deeply about making complex sources approachable.",
-  },
-  {
-    name: "Dr. Khalid Al-Rashidi",
-    title: "Head of Research",
-    bio: "Khalid bridges the classical hadith sciences and computational method, ensuring every feature is grounded in published academic scholarship. He works closely with external reviewers to keep the work faithful to its sources.",
-  },
-  {
-    name: "Priya Krishnan",
-    title: "Lead Data Scientist",
-    bio: "Priya designs the models and pipelines that turn raw narration data into an explorable graph. Her focus is transparency — methods that scholars can inspect, question, and reproduce.",
-  },
-  {
-    name: "Omar Çelik",
-    title: "Head of Product",
-    bio: "Omar shapes how researchers and students actually use the tools, translating scholarly needs into clear, accessible interfaces. He believes good design should meet people wherever they are in their learning.",
-  },
-  {
-    name: "Fatima Zahra El Amrani",
-    title: "Community Director",
-    bio: "Fatima Zahra builds the relationships that make Noorina Labs a community effort, working with scholars, institutions, and contributors around the world. She leads outreach, partnerships, and our open-collaboration programmes.",
-  },
-  {
-    name: "Daniel Okafor",
-    title: "Senior Engineer",
-    bio: "Daniel works across the data acquisition and ingestion stack, keeping sources flowing cleanly into the platform. He has a particular love for the unglamorous work that makes everything else dependable.",
   },
 ];

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -2,21 +2,31 @@
  * Team member data for the /team page.
  *
  * This is intentionally a plain, typed array so non-engineers can edit a
- * member's name, title, or bio without touching page markup. To add or remove
- * a member, edit this list — the page renders one card per entry.
+ * member's name, title, or bio without touching page markup. The page renders
+ * one card per entry.
  *
- * Pre-launch (#138): this list holds only real, consenting people. The earlier
- * fabricated example members (an invented CTO, Head of Research, etc.) were
- * removed so the launch never presents fictitious staff. Add real teammates
- * here — with their consent — as confirmed bios become available.
+ * Pre-launch (#138): the page must never present fictitious staff. The list
+ * holds two kinds of entry:
+ *   - a real, consenting person (`name` + `bio`), and
+ *   - an *open role* (`open: true`, role title only) — a position that exists
+ *     on the roadmap but is not yet filled. Open roles carry NO invented name,
+ *     bio, or photo; the card shows the role title and a "to be announced"
+ *     status with a neutral silhouette avatar.
  *
- * Photos: every member currently uses a generated monogram placeholder (see
- * `avatarFor` in team.astro). When a real portrait is available, drop it in
+ * The earlier seven cards listed one real person and six fabricated people
+ * (an invented CTO, Head of Research, etc.). The fabricated identities were
+ * replaced by honest open-role cards. When a role is filled, convert its entry
+ * to a real member — add the person's `name` and `bio` (with their consent) and
+ * drop the `open` flag.
+ *
+ * Photos: filled members use a generated monogram placeholder (see `avatarFor`
+ * in team.astro). When a real portrait is available, drop it in
  * `public/images/team/` and set the member's `photo` field to its path
  * (e.g. "/images/team/yusuf-french.jpg"); the page prefers `photo` when set.
  */
 
-export interface TeamMember {
+/** A real, consenting team member with a published name and bio. */
+export interface FilledMember {
   /** Full display name. */
   name: string;
   /** Role / job title (rendered in uppercase). */
@@ -25,7 +35,18 @@ export interface TeamMember {
   bio: string;
   /** Optional path to a real portrait under /public; falls back to a monogram. */
   photo?: string;
+  open?: false;
 }
+
+/** A role that exists on the roadmap but is not yet filled — no person attached. */
+export interface OpenRole {
+  /** Role / job title shown on the card. */
+  title: string;
+  /** Marks this entry as an unfilled position (renders "to be announced"). */
+  open: true;
+}
+
+export type TeamMember = FilledMember | OpenRole;
 
 export const team: TeamMember[] = [
   {
@@ -33,4 +54,12 @@ export const team: TeamMember[] = [
     title: "Executive Director",
     bio: "Yusuf founded Noorina Labs to build open, rigorous tools for the Islamic scholarly tradition. He sets the organisation's direction and stewards its commitment to scholarship-first, open-by-default work.",
   },
+  // Open roles: real positions we are growing into, not yet filled. No invented
+  // names, photos, or bios — each card advertises the opening honestly.
+  { title: "Chief Technology Officer", open: true },
+  { title: "Head of Research", open: true },
+  { title: "Lead Data Scientist", open: true },
+  { title: "Head of Product", open: true },
+  { title: "Community Director", open: true },
+  { title: "Senior Engineer", open: true },
 ];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -71,7 +71,7 @@ const resolvedOgImage = ogImage.startsWith("http")
       browser's encoding prescan finds it (nginx sets no charset header, so this
       meta is the only encoding signal). Keep it — and viewport — as the first
       children of <head>, ahead of the theme block below; otherwise multibyte
-      content (e.g. "Çelik" on /team) mojibakes. The theme init does not depend
+      content (e.g. em dashes, accented names, or Arabic text) mojibakes. The theme init does not depend
       on coming first — the charset prescan is independent of script position.
     -->
     <meta charset="utf-8" />

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -2,12 +2,15 @@
 /**
  * The Team page (/team) — replaces the former /about page.
  *
- * Renders one card per member from src/data/team.ts: a portrait on the left,
- * name + title + bio on the right. Cards stack to a single column on mobile.
+ * Renders one card per entry from src/data/team.ts. Two card shapes:
+ *   - a filled member: portrait + name + title + bio, and
+ *   - an open role (#138): role title + "to be announced" status + a neutral
+ *     silhouette avatar, with no invented name, photo, or bio.
+ * Cards stack to a single column on mobile.
  *
- * Photos are generated monogram placeholders until real portraits are supplied
- * (set a member's `photo` field in src/data/team.ts to override). Card styling
- * is built on design-system tokens, matching the home page's card idiom.
+ * Filled-member photos are generated monogram placeholders until real portraits
+ * are supplied (set a member's `photo` field in src/data/team.ts to override).
+ * Card styling is built on design-system tokens, matching the home page idiom.
  */
 import PageLayout from "../layouts/PageLayout.astro";
 import { team } from "../data/team.ts";
@@ -45,6 +48,28 @@ function avatarFor(name: string): string {
 
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
+
+/**
+ * Build a neutral, person-free silhouette avatar for an open (unfilled) role.
+ * Deliberately muted (light parchment field, no initials) so it reads as an
+ * empty placeholder rather than a real person — it carries no identity. It is
+ * decorative: cards render it with empty alt + aria-hidden, since the role
+ * title and status text already convey the meaning.
+ *
+ * Colours are literal sRGB approximations of the design-system warm palette
+ * (a data-URI SVG can't reference CSS tokens), kept lighter than `avatarFor`
+ * so filled and open cards are visually distinct.
+ */
+function openAvatar(): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+  <rect width="160" height="160" fill="#efe9dd"/>
+  <circle cx="80" cy="80" r="62" fill="none" stroke="#cdbfa3" stroke-width="3"/>
+  <circle cx="80" cy="66" r="22" fill="#b39169"/>
+  <path d="M48 120 a32 28 0 0 1 64 0 Z" fill="#b39169"/>
+</svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
 ---
 
 <PageLayout title={title} description={description}>
@@ -61,24 +86,43 @@ function avatarFor(name: string): string {
 
       <ul class="team-grid" role="list">
         {
-          team.map((member) => (
-            <li class="team-card">
-              <img
-                class="team-photo"
-                src={member.photo ?? avatarFor(member.name)}
-                alt={`Portrait of ${member.name}`}
-                width="160"
-                height="160"
-                loading="lazy"
-                decoding="async"
-              />
-              <div class="team-body">
-                <p class="team-bio">{member.bio}</p>
-                <p class="team-name">{member.name}</p>
-                <p class="team-role">{member.title}</p>
-              </div>
-            </li>
-          ))
+          team.map((member) =>
+            member.open ? (
+              <li class="team-card team-card--open">
+                <img
+                  class="team-photo"
+                  src={openAvatar()}
+                  alt=""
+                  aria-hidden="true"
+                  width="160"
+                  height="160"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div class="team-body">
+                  <p class="team-name">{member.title}</p>
+                  <p class="team-status">To be announced</p>
+                </div>
+              </li>
+            ) : (
+              <li class="team-card">
+                <img
+                  class="team-photo"
+                  src={member.photo ?? avatarFor(member.name)}
+                  alt={`Portrait of ${member.name}`}
+                  width="160"
+                  height="160"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div class="team-body">
+                  <p class="team-bio">{member.bio}</p>
+                  <p class="team-name">{member.name}</p>
+                  <p class="team-role">{member.title}</p>
+                </div>
+              </li>
+            ),
+          )
         }
       </ul>
     </div>
@@ -174,6 +218,23 @@ function avatarFor(name: string): string {
     letter-spacing: 0.05em;
     color: var(--color-primary);
     margin-top: 0.15rem;
+  }
+
+  /* Open-role status ("To be announced") — muted, so it reads as a placeholder
+     rather than an active person's title. */
+  .team-status {
+    font-family: var(--font-body);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted-foreground);
+    margin-top: 0.15rem;
+  }
+
+  /* Open-role cards centre their (text-only) body beside the silhouette. */
+  .team-card--open .team-body {
+    justify-content: center;
   }
 
   /* Photo-left / text-right from the small-tablet breakpoint up; stacked below. */


### PR DESCRIPTION
## Summary

Closes #138. The `/team` page shipped **seven** cards: one real person (the founder) and **six fabricated people** ("Dr. Amina Bello", "Dr. Khalid Al-Rashidi", "Priya Krishnan", "Omar Çelik", "Fatima Zahra El Amrani", "Daniel Okafor"). Presenting invented staff at production launch is the credibility problem the owner flagged.

## Approach (owner-directed)

Per the owner's decision: **keep the real founder card, and represent the six unfilled roles as honest "open role" cards** — no invented identities, no fake photos/bios.

Each open-role card shows:
- the **role title** (e.g. "Head of Research", "Lead Data Scientist"),
- a muted **"To be announced"** status, and
- a neutral, **person-free silhouette avatar** (decorative — empty `alt` + `aria-hidden`).

The signal is "these roles exist on the roadmap, not yet filled" — with zero fabricated people. When a role is filled, its data entry is converted to a real member (add `name` + `bio` with consent, drop the `open` flag).

The page structure is unchanged, so the load-bearing dependencies all keep working: the homepage hero **"Meet the Team" CTA**, the **`/about` → `/team` redirect** (`astro.config.mjs`), the **404 page** link, and the **lp#69 CSS-regression probe** (`tests/e2e/regression-lp69.spec.ts`).

## Pre-launch placeholder sweep

The issue asked to sweep for other placeholder/lorem/fake content. I checked the homepage and all `src/` content:

- **Stats** (`1.9B Muslims worldwide`, `14+ centuries of scholarship`, `0 cross-tradition graph tools`) — factual claims, not placeholders. Kept.
- **Guiding-principle blockquote** — a mission statement with **no fabricated attribution**. Kept.
- **No** lorem/ipsum/dummy/testimonial/fake-link content found anywhere else.

The fabricated staff was the only fabricated content on the site.

## Changes

- `src/data/team.ts` — model the list as a discriminated union: `FilledMember` (real name + bio) and `OpenRole` (title only, `open: true`). Founder stays; the six fabricated people become open roles. Header comment documents the convention.
- `src/pages/team.astro` — add `openAvatar()` (muted parchment silhouette, no initials) and branch the card render so open roles show title + "To be announced"; add `.team-status` style and an open-card body modifier.
- `src/layouts/BaseLayout.astro` — the charset comment cited `"Çelik" on /team` as its multibyte example; that content no longer exists, so the example is degeneralized to "em dashes, accented names, or Arabic text" (still-present multibyte content keeps the charset note load-bearing).

## Verification (green-before-push)

All run locally against the wave-5 worktree:

- `eslint .` — clean
- `prettier --check` (CI scope `src/**`) — clean
- `npx astro check` — **0 errors**, 0 warnings (hints only)
- `npm run build` — success; `dist/team/index.html` contains the founder + 6 "To be announced" cards and **zero** fabricated names
- `npm test` (vitest) — **82 passed**
- `npx playwright test --project=desktop-chromium` — **25 passed, 3 skipped** (incl. `/team` axe a11y)

No test asserted member identities or a member count, so no test changes were needed.

> Note (pre-existing, out of scope): `npm run lint` runs `prettier --check .` over the whole repo and flags 5 **non-`src/`** root files (`.cspell.json`, `RUNBOOK.md`, `docs/branch-protection.md`, `.markdownlint-cli2.jsonc`, `SPEC.md`). CI's prettier step is scoped to `src/**/*.{ts,tsx,astro,css,md,json}`, so this is not a CI gate and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
