### PR TITLE
feat(lp#116): user-facing dark-mode toggle (light/dark/system)

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,132 @@
+---
+/**
+ * ThemeToggle — header control that cycles the colour theme light → dark →
+ * system. The interactive behaviour lives in src/scripts/theme.ts (wired once
+ * from BaseLayout); this component is just the markup + presentation.
+ *
+ * Which icon shows is driven entirely by `html[data-theme-choice]`, set
+ * pre-paint by the BaseLayout inline init, so the correct icon is painted with
+ * no flash. All three icons are rendered; CSS reveals the active one.
+ *
+ * Progressive enhancement: the button does nothing without JS, so it is hidden
+ * until the inline init adds `html.js` (also pre-paint, no layout shift). The
+ * server-rendered aria-label is a sensible default; theme.ts refines it to the
+ * live "Activate to switch to …" wording once it takes over.
+ */
+---
+
+<button
+  type="button"
+  class="theme-toggle"
+  aria-label="Switch color theme"
+  title="Switch color theme"
+  data-theme-toggle
+>
+  <!-- light → sun -->
+  <svg
+    class="theme-icon theme-icon-light"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+
+  <!-- dark → moon -->
+  <svg
+    class="theme-icon theme-icon-dark"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+
+  <!-- system → monitor -->
+  <svg
+    class="theme-icon theme-icon-system"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+    <line x1="8" y1="21" x2="16" y2="21"></line>
+    <line x1="12" y1="17" x2="12" y2="21"></line>
+  </svg>
+</button>
+
+<style>
+  /* Hidden until the inline init confirms JS — the button is inert without it. */
+  .theme-toggle {
+    display: none;
+  }
+
+  :global(html.js) .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    padding: 0.5rem;
+    margin: 0;
+    color: var(--color-foreground);
+    cursor: pointer;
+    line-height: 0;
+    border-radius: 0.25rem;
+  }
+
+  .theme-toggle:hover {
+    color: var(--color-primary);
+  }
+
+  .theme-toggle:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+  }
+
+  /* Show only the icon matching the current choice; default hide all three. */
+  .theme-icon {
+    display: none;
+  }
+
+  :global(html[data-theme-choice="light"]) .theme-icon-light,
+  :global(html[data-theme-choice="dark"]) .theme-icon-dark,
+  :global(html[data-theme-choice="system"]) .theme-icon-system {
+    display: block;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .theme-toggle {
+      transition: none;
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,7 +64,7 @@ const resolvedOgImage = ogImage.startsWith("http")
 ---
 
 <!doctype html>
-<html lang="en" dir="ltr" data-theme="light">
+<html lang="en" dir="ltr" data-theme="light" data-theme-choice="system">
   <head>
     <!--
       charset MUST stay within the first 1024 bytes of the document so the
@@ -78,29 +78,44 @@ const resolvedOgImage = ogImage.startsWith("http")
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <!--
-      Theme init (#128) — resolve data-theme on <html> before first paint.
-      The design system ships its base colour tokens only inside a Tailwind v4
-      `@theme {}` block, which the browser ignores when the dist is imported as
-      plain CSS (BaseLayout's `@noorinalabs/design-system/styles.css` import);
-      the DS's real token values live under `[data-theme="light"|"dark"]`.
+      Theme init (#128, toggle #116) — resolve data-theme on <html> before first
+      paint. The design system ships its base colour tokens only inside a
+      Tailwind v4 `@theme {}` block, which the browser ignores when the dist is
+      imported as plain CSS (BaseLayout's `@noorinalabs/design-system/styles.css`
+      import); the DS's real token values live under `[data-theme="light"|"dark"]`.
       Without this attribute every `--color-*` var is unresolved and the page
-      renders unstyled. This honours a stored choice (the future toggle, #116)
-      then the OS preference; the server-rendered `data-theme="light"` above is
-      the no-JS fallback. The durable fix is DS-side (emit tokens to `:root`).
+      renders unstyled. The durable fix is DS-side (emit tokens to `:root`).
+
+      Two attributes are set, mirroring isnad-graph's model:
+        - data-theme        — the *resolved* light|dark actually painted, the
+                              only thing the DS [data-theme] selectors read.
+        - data-theme-choice — the user's *choice* light|dark|system, the source
+                              of truth the #116 header toggle reads/cycles and
+                              the CSS uses to show the matching toggle icon.
+      Resolution order: a stored choice, else the OS `prefers-color-scheme`. The
+      server-rendered `data-theme="light"`/`data-theme-choice="system"` above are
+      the no-JS fallback. `js` flags that the deferred runtime can take over — the
+      toggle is hidden until then, since it does nothing without JS.
     -->
     <script is:inline>
       (() => {
+        document.documentElement.classList.add("js");
         try {
           const stored = localStorage.getItem("theme");
-          const theme =
-            stored === "light" || stored === "dark"
+          const choice =
+            stored === "light" || stored === "dark" || stored === "system"
               ? stored
-              : window.matchMedia("(prefers-color-scheme: dark)").matches
+              : "system";
+          const resolved =
+            choice === "system"
+              ? window.matchMedia("(prefers-color-scheme: dark)").matches
                 ? "dark"
-                : "light";
-          document.documentElement.dataset.theme = theme;
+                : "light"
+              : choice;
+          document.documentElement.dataset.theme = resolved;
+          document.documentElement.dataset.themeChoice = choice;
         } catch {
-          /* localStorage / matchMedia unavailable — keep the SSR light default */
+          /* localStorage / matchMedia unavailable — keep the SSR defaults */
         }
       })();
     </script>
@@ -164,6 +179,18 @@ const resolvedOgImage = ogImage.startsWith("http")
 
     <!-- Slot for page-level scripts -->
     <slot name="scripts" />
+
+    <!--
+      Theme runtime (#116) — wire up the header dark-mode toggle. The pre-paint
+      inline init above already set data-theme/data-theme-choice (no FOUC); this
+      runtime makes the toggle interactive: cycle light→dark→system, persist the
+      choice, and live-update the resolved theme on OS change while in `system`.
+      See src/scripts/theme.ts and src/components/ThemeToggle.astro.
+    -->
+    <script>
+      import { initThemeToggle } from "../scripts/theme";
+      initThemeToggle();
+    </script>
 
     <!--
       Motion runtime (#121) — scroll-reveal + parallax. Bails immediately on

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,6 +10,7 @@
  * Used by: Homepage (/), The Team (/team), and any general page.
  */
 import BaseLayout from "./BaseLayout.astro";
+import ThemeToggle from "../components/ThemeToggle.astro";
 import { PROD_ISNAD_URL } from "../lib/isnad";
 
 interface Props {
@@ -60,57 +61,61 @@ const footerNav = {
         Noorina Labs
       </a>
 
-      <button
-        type="button"
-        class="nav-toggle"
-        aria-controls="primary-nav"
-        aria-expanded="false"
-        aria-label="Open navigation menu"
-        data-nav-toggle
-      >
-        <svg
-          class="nav-toggle-icon"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-          focusable="false"
+      <div class="nav-controls">
+        <button
+          type="button"
+          class="nav-toggle"
+          aria-controls="primary-nav"
+          aria-expanded="false"
+          aria-label="Open navigation menu"
+          data-nav-toggle
         >
-          <line
-            class="nav-toggle-line nav-toggle-line-top"
-            x1="3"
-            y1="6"
-            x2="21"
-            y2="6"></line>
-          <line
-            class="nav-toggle-line nav-toggle-line-mid"
-            x1="3"
-            y1="12"
-            x2="21"
-            y2="12"></line>
-          <line
-            class="nav-toggle-line nav-toggle-line-bot"
-            x1="3"
-            y1="18"
-            x2="21"
-            y2="18"></line>
-        </svg>
-      </button>
+          <svg
+            class="nav-toggle-icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <line
+              class="nav-toggle-line nav-toggle-line-top"
+              x1="3"
+              y1="6"
+              x2="21"
+              y2="6"></line>
+            <line
+              class="nav-toggle-line nav-toggle-line-mid"
+              x1="3"
+              y1="12"
+              x2="21"
+              y2="12"></line>
+            <line
+              class="nav-toggle-line nav-toggle-line-bot"
+              x1="3"
+              y1="18"
+              x2="21"
+              y2="18"></line>
+          </svg>
+        </button>
 
-      <ul id="primary-nav" role="list" data-nav-list>
-        {
-          headerNav.map((item) => (
-            <li>
-              <a href={item.href}>{item.label}</a>
-            </li>
-          ))
-        }
-      </ul>
+        <ul id="primary-nav" role="list" data-nav-list>
+          {
+            headerNav.map((item) => (
+              <li>
+                <a href={item.href}>{item.label}</a>
+              </li>
+            ))
+          }
+        </ul>
+
+        <ThemeToggle />
+      </div>
     </nav>
   </header>
 
@@ -224,6 +229,14 @@ const footerNav = {
     right: 0;
     z-index: 10;
     padding: 1rem 1.5rem;
+  }
+
+  /* Right-hand controls group: nav links + theme toggle (+ mobile hamburger).
+     Keeps the logo flush-left and the controls together flush-right. */
+  .nav-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
   }
 
   header nav {

--- a/src/scripts/theme.ts
+++ b/src/scripts/theme.ts
@@ -1,0 +1,125 @@
+/*
+ * Theme runtime (#116)
+ * ====================
+ * Drives the header dark-mode toggle (src/components/ThemeToggle.astro). The
+ * pre-paint inline init in BaseLayout.astro already set both attributes on
+ * <html> before first paint (no FOUC); this module only makes the toggle
+ * interactive and keeps `system` mode live.
+ *
+ * Model (mirrors isnad-graph's useTheme — frontend/src/hooks/useTheme.ts):
+ *   - choice   ∈ {light, dark, system}  — the user's selection, persisted in
+ *               localStorage under `theme`, reflected on <html data-theme-choice>.
+ *   - resolved ∈ {light, dark}          — what is actually painted, written to
+ *               <html data-theme>; this is the only thing the design system's
+ *               `[data-theme]` token blocks read. `system` resolves via the OS
+ *               `prefers-color-scheme`.
+ *
+ * Tri-state so a user who never touched the toggle (or who explicitly wants to
+ * follow the OS) keeps tracking `prefers-color-scheme`, while an explicit
+ * light/dark choice pins the theme across navigation and sessions.
+ */
+
+export type ThemeChoice = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+/** localStorage key. Kept as `theme` to match the existing BaseLayout init. */
+export const STORAGE_KEY = "theme";
+
+/** The cycle order the toggle steps through on each activation. */
+const CYCLE: readonly ThemeChoice[] = ["light", "dark", "system"];
+
+/** The OS preference, defensively returning `light` when matchMedia is absent. */
+export function getSystemTheme(): ResolvedTheme {
+  return typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+/** Read the persisted choice, defaulting to `system` for unset/garbage values. */
+export function readStoredChoice(): ThemeChoice {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
+  } catch {
+    /* localStorage unavailable — fall through to the default */
+  }
+  return "system";
+}
+
+/** Resolve a choice to the concrete theme that gets painted. */
+export function resolveTheme(choice: ThemeChoice): ResolvedTheme {
+  return choice === "system" ? getSystemTheme() : choice;
+}
+
+/** The next choice in the light → dark → system → light cycle. */
+export function nextChoice(choice: ThemeChoice): ThemeChoice {
+  return CYCLE[(CYCLE.indexOf(choice) + 1) % CYCLE.length];
+}
+
+/** Human-readable accessible name for the toggle in its current state. */
+export function toggleLabel(choice: ThemeChoice): string {
+  return `Color theme: ${choice}. Activate to switch to ${nextChoice(choice)}.`;
+}
+
+/**
+ * Apply a choice: write both <html> attributes and reflect the state onto the
+ * toggle button (if present). Does NOT persist — callers decide when to write
+ * localStorage so a live OS change in `system` mode doesn't rewrite storage.
+ */
+export function applyChoice(
+  choice: ThemeChoice,
+  button?: HTMLElement | null,
+): void {
+  const root = document.documentElement;
+  root.dataset.theme = resolveTheme(choice);
+  root.dataset.themeChoice = choice;
+  if (button) {
+    button.setAttribute("aria-label", toggleLabel(choice));
+    button.setAttribute("title", toggleLabel(choice));
+  }
+}
+
+/** Persist the choice, swallowing storage failures (private mode, etc.). */
+function persistChoice(choice: ThemeChoice): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, choice);
+  } catch {
+    /* persistence unavailable — the in-session attribute change still holds */
+  }
+}
+
+/**
+ * Wire up the header toggle. Safe to call once per page load. Idempotent: if no
+ * toggle is on the page (or it has already been initialised) it is a no-op.
+ */
+export function initThemeToggle(): void {
+  const button = document.querySelector<HTMLButtonElement>(
+    "[data-theme-toggle]",
+  );
+  if (!button || button.dataset.themeReady === "true") return;
+  button.dataset.themeReady = "true";
+
+  // The inline init already painted the correct theme; sync the button's label
+  // to the current choice without re-touching the attributes mid-load.
+  let choice = readStoredChoice();
+  button.setAttribute("aria-label", toggleLabel(choice));
+  button.setAttribute("title", toggleLabel(choice));
+
+  button.addEventListener("click", () => {
+    choice = nextChoice(choice);
+    persistChoice(choice);
+    applyChoice(choice, button);
+  });
+
+  // Keep `system` live: when the OS flips, re-resolve without rewriting storage
+  // (storage still holds `system`, so the choice itself is unchanged).
+  if (typeof window.matchMedia === "function") {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    mq.addEventListener("change", () => {
+      if (choice === "system") applyChoice(choice, button);
+    });
+  }
+}

--- a/tests/e2e/theme-toggle.spec.ts
+++ b/tests/e2e/theme-toggle.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/*
+ * Dark-mode toggle (#116)
+ * =======================
+ * The header toggle cycles data-theme-choice light → dark → system and writes
+ * the resolved light|dark to <html data-theme>, which is the only thing the
+ * design system's [data-theme] token blocks read. These tests pin the OS
+ * preference (emulateMedia) so `system` is deterministic, then assert that
+ * flipping the toggle actually re-resolves the DS colour tokens and that the
+ * choice survives navigation.
+ */
+
+const toggle = "[data-theme-toggle]";
+
+/** Resolved value of a DS colour token on <html> — empty if tokens don't resolve. */
+async function bgToken(page: Page): Promise<string> {
+  return page.evaluate(() =>
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("--color-background")
+      .trim(),
+  );
+}
+
+async function choice(page: Page): Promise<string | null> {
+  return page.evaluate(
+    () => document.documentElement.dataset.themeChoice ?? null,
+  );
+}
+
+async function resolved(page: Page): Promise<string | null> {
+  return page.evaluate(() => document.documentElement.dataset.theme ?? null);
+}
+
+/** Click the toggle until data-theme-choice reaches the target (max one full cycle). */
+async function cycleTo(page: Page, target: string): Promise<void> {
+  for (let i = 0; i < 3 && (await choice(page)) !== target; i++) {
+    await page.locator(toggle).click();
+  }
+  expect(await choice(page)).toBe(target);
+}
+
+test.describe("Dark-mode toggle (#116)", () => {
+  test.use({ colorScheme: "light" });
+
+  test("no flash: data-theme + DS tokens resolve on first load", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // The pre-paint inline init must have set both attributes.
+    expect(await resolved(page)).toMatch(/^(light|dark)$/);
+    expect(await choice(page)).toBe("system");
+    // Memory regression guard: tokens are EMPTY unless data-theme is set.
+    expect(await bgToken(page)).not.toBe("");
+  });
+
+  test("toggle flips the resolved theme and re-resolves DS colour tokens", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.locator(toggle)).toBeVisible();
+
+    await cycleTo(page, "light");
+    const bgLight = await bgToken(page);
+    expect(await resolved(page)).toBe("light");
+
+    await cycleTo(page, "dark");
+    const bgDark = await bgToken(page);
+    expect(await resolved(page)).toBe("dark");
+
+    // The actual painted colour token must differ between light and dark.
+    expect(bgDark).not.toBe(bgLight);
+    expect(bgLight).not.toBe("");
+    expect(bgDark).not.toBe("");
+  });
+
+  test("choice persists across navigation (localStorage)", async ({ page }) => {
+    await page.goto("/");
+    await cycleTo(page, "dark");
+    expect(await page.evaluate(() => localStorage.getItem("theme"))).toBe(
+      "dark",
+    );
+
+    await page.goto("/team");
+    // No flash on the next page either — dark is applied pre-paint.
+    expect(await resolved(page)).toBe("dark");
+    expect(await choice(page)).toBe("dark");
+  });
+
+  test("system mode tracks the OS preference", async ({ page }) => {
+    await page.goto("/");
+    await cycleTo(page, "system");
+    expect(await resolved(page)).toBe("light"); // colorScheme: light
+
+    await page.emulateMedia({ colorScheme: "dark" });
+    // The matchMedia change listener re-resolves without a reload.
+    await expect.poll(() => resolved(page)).toBe("dark");
+    expect(await choice(page)).toBe("system"); // choice itself unchanged
+  });
+});

--- a/tests/unit/layouts.test.ts
+++ b/tests/unit/layouts.test.ts
@@ -13,9 +13,12 @@ describe("BaseLayout", () => {
 
   it("renders valid HTML5 document", () => {
     expect(html).toContain("<!DOCTYPE html>");
-    // data-theme is the server-rendered no-JS default (#128); the pre-paint
-    // init script may upgrade it to the OS/stored preference at runtime.
-    expect(html).toContain('<html lang="en" dir="ltr" data-theme="light">');
+    // data-theme/data-theme-choice are the server-rendered no-JS defaults
+    // (#128, toggle #116); the pre-paint init script may upgrade them to the
+    // OS/stored preference at runtime.
+    expect(html).toContain(
+      '<html lang="en" dir="ltr" data-theme="light" data-theme-choice="system">',
+    );
     expect(html).toContain('<meta charset="utf-8">');
     expect(html).toContain("viewport");
   });

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import {
+  STORAGE_KEY,
+  getSystemTheme,
+  readStoredChoice,
+  resolveTheme,
+  nextChoice,
+  toggleLabel,
+  applyChoice,
+  initThemeToggle,
+  type ThemeChoice,
+} from "../../src/scripts/theme";
+
+const distDir = resolve(import.meta.dirname, "../../dist");
+
+function readPage(path: string): string {
+  return readFileSync(resolve(distDir, path), "utf-8");
+}
+
+/** Stub matchMedia so `system` resolution is deterministic in happy-dom. */
+function mockSystemDark(dark: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: dark && query.includes("dark"),
+    media: query,
+    onchange: null,
+    addEventListener(): void {},
+    removeEventListener(): void {},
+    addListener(): void {},
+    removeListener(): void {},
+    dispatchEvent(): boolean {
+      return false;
+    },
+  })) as typeof window.matchMedia;
+}
+
+describe("theme model (#116)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-theme-choice");
+  });
+
+  it("cycles light → dark → system → light", () => {
+    expect(nextChoice("light")).toBe("dark");
+    expect(nextChoice("dark")).toBe("system");
+    expect(nextChoice("system")).toBe("light");
+  });
+
+  it("resolves system to the OS preference and pins explicit choices", () => {
+    mockSystemDark(true);
+    expect(resolveTheme("system")).toBe("dark");
+    expect(resolveTheme("light")).toBe("light");
+    expect(resolveTheme("dark")).toBe("dark");
+
+    mockSystemDark(false);
+    expect(resolveTheme("system")).toBe("light");
+  });
+
+  it("getSystemTheme follows prefers-color-scheme", () => {
+    mockSystemDark(true);
+    expect(getSystemTheme()).toBe("dark");
+    mockSystemDark(false);
+    expect(getSystemTheme()).toBe("light");
+  });
+
+  it("defaults to system for unset or garbage stored values", () => {
+    expect(readStoredChoice()).toBe("system");
+    localStorage.setItem(STORAGE_KEY, "purple");
+    expect(readStoredChoice()).toBe("system");
+    localStorage.setItem(STORAGE_KEY, "dark");
+    expect(readStoredChoice()).toBe("dark");
+  });
+
+  it("builds an accessible label naming the next choice", () => {
+    expect(toggleLabel("light")).toContain("light");
+    expect(toggleLabel("light")).toContain("switch to dark");
+    expect(toggleLabel("system")).toContain("switch to light");
+  });
+
+  it("applyChoice writes both <html> attributes (resolved + choice)", () => {
+    mockSystemDark(true);
+    applyChoice("system");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.dataset.themeChoice).toBe("system");
+
+    applyChoice("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(document.documentElement.dataset.themeChoice).toBe("light");
+  });
+});
+
+describe("initThemeToggle wiring (#116)", () => {
+  beforeEach(() => {
+    mockSystemDark(false);
+    localStorage.clear();
+    document.documentElement.dataset.theme = "light";
+    document.documentElement.dataset.themeChoice = "system";
+    document.body.innerHTML = `<button data-theme-toggle aria-label="Switch color theme"></button>`;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function btn(): HTMLButtonElement {
+    return document.querySelector<HTMLButtonElement>("[data-theme-toggle]")!;
+  }
+
+  it("on click: cycles the choice, persists it, and repaints data-theme", () => {
+    initThemeToggle();
+    // starts at system (default) → click → light
+    btn().click();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+    expect(document.documentElement.dataset.themeChoice).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+
+    // light → dark
+    btn().click();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    // dark → system (OS=light here) → resolves to light
+    btn().click();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("system");
+    expect(document.documentElement.dataset.themeChoice).toBe("system");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("starts the cycle from the persisted choice", () => {
+    localStorage.setItem(STORAGE_KEY, "light" satisfies ThemeChoice);
+    initThemeToggle();
+    btn().click(); // light → dark
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+  });
+
+  it("updates the toggle's accessible label as it cycles", () => {
+    initThemeToggle();
+    btn().click();
+    expect(btn().getAttribute("aria-label")).toContain("light");
+    expect(btn().getAttribute("aria-label")).toContain("switch to dark");
+  });
+
+  it("is idempotent — a second init does not double-bind the handler", () => {
+    initThemeToggle();
+    initThemeToggle();
+    btn().click(); // a double-bound handler would advance two steps
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  });
+});
+
+describe("Header theme-toggle markup (#116)", () => {
+  const html = readPage("index.html");
+
+  it("renders the toggle button in the header", () => {
+    expect(html).toContain("data-theme-toggle");
+  });
+
+  it("ships all three choice icons (light/dark/system)", () => {
+    expect(html).toContain("theme-icon-light");
+    expect(html).toContain("theme-icon-dark");
+    expect(html).toContain("theme-icon-system");
+  });
+
+  it("server-renders the no-JS theme defaults on <html>", () => {
+    expect(html).toContain('data-theme="light"');
+    expect(html).toContain('data-theme-choice="system"');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a user-facing **dark-mode toggle** to the landing-page header, activating
the dormant `[data-theme]` mechanism shipped by lp#43/PR#115 and #128. Until
now the LP only auto-flipped on the OS `prefers-color-scheme` media query, with
no control for the visitor. Closes #116.

The toggle is a single header button that **cycles light -> dark -> system**.

## How it works

Model mirrors isnad-graph's `useTheme` (`frontend/src/hooks/useTheme.ts`), kept
framework-neutral (Astro-native, no React):

- **choice** in `{light, dark, system}` - the user's selection, persisted in
  `localStorage["theme"]`, reflected on `<html data-theme-choice>`.
- **resolved** in `{light, dark}` - what is actually painted, written to
  `<html data-theme>` (the only thing the DS `[data-theme]` token blocks read).
  `system` resolves via `prefers-color-scheme` and stays **live** via a
  `matchMedia` change listener.

Implementation follows the existing **inline-init + deferred-runtime + component**
pattern already used for motion (#121):

| File | Role |
|------|------|
| `src/layouts/BaseLayout.astro` | Pre-paint inline init (no FOUC): resolves the tri-state choice, sets `data-theme` + `data-theme-choice`, adds `html.js` so the JS-only toggle stays hidden without scripting. Wires the deferred runtime. |
| `src/scripts/theme.ts` | Deferred runtime: cycle on click, persist, repaint, re-resolve on OS change while in `system`. Pure helpers exported for unit test; `initThemeToggle` is idempotent. |
| `src/components/ThemeToggle.astro` | Accessible header button, three icons (sun/moon/monitor) revealed by `html[data-theme-choice]` so the right icon paints with no flash. Reuses DS tokens. |
| `src/layouts/PageLayout.astro` | Toggle grouped with nav in a flex `.nav-controls`; visible at all viewports (not collapsed into the mobile menu). |

`charset` stays within the #128 1024-byte encoding-prescan window (byte ~585).

## Acceptance criteria

- [x] Header toggle switches `[data-theme]` light/dark/system
- [x] Choice persists across navigation (localStorage)
- [x] No flash-of-wrong-theme on load (pre-paint init)
- [x] Playwright test asserts the toggle flips computed colors

## Tests

- `tests/unit/theme.test.ts` - model + wiring (cycle, resolve, persist,
  idempotency, label) + dist markup assertions.
- `tests/e2e/theme-toggle.spec.ts` - toggle flips `data-theme` **and**
  re-resolves the DS `--color-background` token (light != dark, both non-empty,
  guarding the "tokens empty without `data-theme`" regression), persistence
  across navigation, no-FOUC on first load, live `system` tracking.
- `tests/unit/layouts.test.ts` updated for the new `data-theme-choice` attribute.

## Local verification (green)

eslint, prettier `--check`, `astro check` (0 errors), build, **95 unit**,
**90 e2e** (6 pre-existing mobile-only skips; axe accessibility incl.).

## Reviewers

@ (Cedric Novak) and @ (Nazia Rahman)
