### PR TITLE
docs(README): document required pre-commit + pre-push hook install (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# noorinalabs-landing-page
+
+Organization landing page — Astro.
+
+The public marketing site for NoorinALabs: a statically generated Astro + Tailwind site whose pages, layouts, and content collections live under `src/`. It is built to static HTML at deploy time and served from an Nginx container.
+
+## Git hooks (required)
+
+This repo mirrors its CI checks locally via [pre-commit](https://pre-commit.com/). After cloning, install BOTH hook stages once:
+
+```bash
+pre-commit install                       # commit-stage checks
+pre-commit install --hook-type pre-push  # push-stage checks
+```
+
+- **Commit stage** runs: gitleaks (secret detection), actionlint (workflow lint), ESLint, and Prettier `--check`.
+- **Pre-push stage** runs: `astro check` (type check), `npm run build`, and unit tests (`npm test`).
+
+The commit stage stays fast so the commit loop is snappy; the heavier compile, build, and test surface runs at push time, before code leaves the machine. Run `npm ci` once after cloning so `node_modules` is present for the local hooks.
+
+These mirror `.github/workflows/ci.yml` so failures surface locally before a PR (org-wide local⇄CI parity, noorinalabs-main#684). The kind-level mirror is itself enforced by the `Pre-commit ⇄ CI sync-drift gate` job, which fails the build if a check drops from one side. The Playwright E2E suite runs in CI only (not as a local hook). Never bypass with `--no-verify`. If `pre-commit install` "cowardly refuses" because `core.hooksPath` is set — some clones inherited a stale path from a repo rename — run `git config --unset core.hooksPath` first.


### PR DESCRIPTION
## What

Adds a `README.md` for the landing page (Astro) with a **Git hooks (required)** section documenting the mandatory one-time local-hook setup, so a fresh clone doesn't silently run zero checks before CI.

## Details

- Project title, one-line description ("Organization landing page — Astro"), and a short "what's here" line.
- Enumerates this repo's **real** per-stage hooks (read from `.pre-commit-config.yaml` + `.github/workflows/ci.yml` at HEAD):
  - **Commit stage:** gitleaks, actionlint, ESLint, Prettier `--check`.
  - **Pre-push stage:** `astro check`, `npm run build`, unit tests.
- References the CI-mirroring config + the `Pre-commit ⇄ CI sync-drift gate`, and the org-wide local⇄CI parity rule (noorinalabs-main#684). Notes the Playwright E2E suite is CI-only, and the `core.hooksPath` unset workaround for clones with a stale path.

## Verification

Ran both hook stages locally — all green (gitleaks/actionlint/eslint/prettier on commit; astro-check/build/unit-tests on push).

Part of cross-repo meta noorinalabs-main#718.

Closes #147

Needs 2 reviewers per charter.
