### PR TITLE
chore(memory): seed landing-page project memory (#740)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Project Memory — noorinalabs-landing-page
+
+- [LP↔DS icon consumption](project_lp_ds_icon_consumption.md) — Astro LP can't import DS React icons; Icon.astro mirrors geometry; ds#103=neutral iconPaths. lp#119.

--- a/.claude/memory/project_lp_ds_icon_consumption.md
+++ b/.claude/memory/project_lp_ds_icon_consumption.md
@@ -1,0 +1,18 @@
+---
+name: project_lp_ds_icon_consumption
+description: "Landing-page (Astro) cannot import the design-system's React-only icons; geometry-mirror is interim, ds#103 tracks the framework-neutral export. Plus npm-auth recipe + stale publish-lore correction."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 090bf6d5-0d19-47c9-9b85-67bfff1c5396
+---
+
+**The design system ships icons ONLY as React components** (`@noorinalabs/design-system/icons` → `React.createElement` bundled in `dist/index.js`). The **landing page is pure Astro with no React renderer**, so it CANNOT `import` them. `noorinalabs-landing-page/src/components/Icon.astro` therefore reproduces the DS Qalam geometry by hand (graph→GraphExplorer, user→Narrators, search→Search, compare→Compare, book→Hadiths; 24×24, currentColor, 1.5px stroke). This is an **interim mirror** — the real "consume from DS" fix is **noorinalabs-design-system#103** (framework-neutral `iconPaths` export; refactor React icons to render from it). Once ds#103 ships, swap Icon.astro's hand-copied geometry for a direct import. Landed in lp#119 / PR#126 (P4W3). The icon geometry source-of-truth = the **published bundle**, not the DS wave-11 source (which can drift); extract via grep on `node_modules/@noorinalabs/design-system/dist/index.js`.
+
+**Stale-lore correction:** the published `@noorinalabs/design-system@0.0.4-wave10.0` `styles.css` DOES ship `--color-brand-navy`/`--color-brand-gold`, the full semantic token set, AND both `prefers-color-scheme` + `[data-theme]` dark mode. The old global.css comment claiming "DS publish pipeline broken since v0.0.1, brand tokens may be absent, inline OKLCH fallbacks load-bearing" is WRONG for current versions. Kofi's lp#118 (PR#125) removed that comment + the whole LP-local navy/gold/neutral ladder, folding the LP onto DS semantic tokens.
+
+**npm-auth recipe (LP/DS install):** `@noorinalabs/*` resolves from GitHub Packages (`https://npm.pkg.github.com`); `NODE_AUTH_TOKEN` is unset in the sandbox. Install with: write `//npm.pkg.github.com/:_authToken=$(gh auth token)` + `@noorinalabs:registry=...` to a temp file, then `NPM_CONFIG_USERCONFIG=/tmp/xxx npm install`. Do NOT commit the token.
+
+**DS export bug (surfaced, filed in ds#103 notes):** published pkg `exports["./icons"]` → `./dist/icons/index.js` which does NOT exist (only `.d.ts` there; all JS is in `dist/index.js`). The `./icons` subpath import appears broken.
+
+Related: [[project_data_pipeline_architecture]] is unrelated; this is design-system/landing-page cross-repo. CI format-check is scoped `src/**` only (repo-root files like RUNBOOK.md fail local `prettier --check .` but CI never checks them).

--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
     "node_modules/**",
     "dist/**",
     ".astro/**",
-    ".claude/worktrees/**"
+    ".claude/worktrees/**",
+    ".claude/memory/**"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Thumbs.db
 # Claude Code — local-only consultation sentinels
 .claude/.consulted/
 
+# Claude Code — per-session, machine-local memory handoff (Stop hook)
+.claude/memory/session_handoff.md
+
 # Lighthouse reports
 lighthouse-report.html
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -43,6 +43,9 @@ exclude_path = [
   "dist",
   ".astro",
   ".claude/worktrees",
+  # Project memory: append-only notes use [[wikilinks]], not markdown links —
+  # excluded from the internal link gate, same call as the parent org corpus.
+  ".claude/memory",
 ]
 
 # A relative link with no matching file is the failure we DO want to surface.

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -50,6 +50,9 @@
     "node_modules/**",
     "dist/**",
     ".astro/**",
-    ".claude/worktrees/**"
+    ".claude/worktrees/**",
+    // Project memory: dense append-only note prose with names, SHAs, and
+    // [[wikilinks]] — same exclusion call as the parent org corpus.
+    ".claude/memory/**"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,13 @@ See the org-level charter at `noorinalabs-main/.claude/team/charter.md` and this
 ## Status
 
 Project not yet scaffolded. Team roster and charter established. Ready for PRD and initial scaffolding phase.
+
+## Project Memory
+
+Project memory is **version-controlled in this repo** at `.claude/memory/`, not in the user-space auto-memory directory. This makes the accumulated state **transferable**: a developer who pulls a branch gets the memory with it, with zero per-machine setup. The index below is auto-loaded into every session via the committed import line at the end of this section.
+
+`MEMORY.md` is the always-loaded index (one line per memory); the individual topic files in `.claude/memory/*.md` are read on demand when a line looks relevant. To record a memory, create or edit `.claude/memory/<kebab-slug>.md` with the standard frontmatter (`name`, `description`, `metadata.type`), add a one-line pointer to `MEMORY.md`, and **commit it** so it travels with the branch.
+
+> `.claude/memory/**` is excluded from the markdown/cspell/lychee linters (dense append-only note prose with names, SHAs, and `[[wikilinks]]`). The Stop-hook `session_handoff.md` is gitignored (per-session, machine-local churn).
+
+@.claude/memory/MEMORY.md


### PR DESCRIPTION
## Summary

Seeds `noorinalabs-landing-page` with version-controlled, transferable project memory, mirroring the parent org pattern: a `CLAUDE.md` `@import` of an always-loaded `MEMORY.md` index plus on-demand topic files under `.claude/memory/`.

Part of noorinalabs/noorinalabs-main#740

## Changes

- **`.claude/memory/`** — new dir with `MEMORY.md` (one-line index) and `project_lp_ds_icon_consumption.md` (copied **verbatim** from the parent corpus; its `[[wikilinks]]` dangle here, acceptable for a seed).
- **`CLAUDE.md`** — adds a `## Project Memory` section ending with `@.claude/memory/MEMORY.md`.
- **Doc-lint exclusions** — `.claude/memory/**` excluded from the three docs-lint gates that `docs.yml` runs (markdownlint `ignores`, cspell `ignorePaths`, lychee `exclude_path`), same call as the parent org corpus.
  - Note: the spawn brief assumed LP had no markdown/cspell/lychee configs. It actually has all three plus a `docs.yml` workflow, so the minimal exclusions were added per the brief's stated contingency ("if a markdown/spell lint runs despite no config file, add the minimal exclusion").
- **`.gitignore`** — ignores the per-session Stop-hook `session_handoff.md` (`.claude/.consulted/` was already ignored).

## Verification (local, green before push)

- markdownlint-cli2: 0 errors (17 files; `.claude/memory/**` confirmed excluded from the Finding glob)
- cspell over `CLAUDE.md`: 0 issues
- config-lint (YAML/JSON parse): clean
- pre-commit ⇄ CI sync-drift gate: pass
- actionlint: pass (no workflow changes)
- Commit hooks (gitleaks, prettier): passed; push hooks (astro-check, build, unit-tests): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNK9q1SAds2ZmHQ88oLvxn
