### PR TITLE
docs(claude): add zsh shell-environment note to CLAUDE.md (#759)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ This file provides guidance to Claude Code when working in the landing page repo
 - **Accessibility:** WCAG 2.2 AA minimum
 - **Deployment:** Static hosting (Vercel, Cloudflare Pages, or similar)
 
+## Shell environment
+
+The development shell is **zsh** (not bash). Write zsh-safe terminal commands and avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs such as `…?ref=main` URLs). Prefer POSIX-portable constructs; use `bash -c '...'` explicitly when bash is genuinely required. Canonical do/don't list: org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in `noorinalabs-main`.
+
 ## Team
 
 | Role                    | Name                   | Level          | File                                 |


### PR DESCRIPTION
## Summary

Adds a concise **"Shell environment"** subsection to this repo's `CLAUDE.md`, documenting that the development shell is **zsh** (not bash) and listing the bash-only idioms to avoid (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs). Points to the canonical do/don't list in org `docs/TOOLCHAIN.md` and `noorinalabs-main` `ontology/conventions.md`.

Placed after **Tech Stack** as a top-level section; no restructuring of existing content.

Part of #759

## Verification

- Pre-commit (gitleaks, prettier): Passed
- Pre-push (astro-check, build, unit-tests): Passed
