### PR TITLE
feat(ci): Dockerfile base-pin gate + local-hooks README docs (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,33 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+
+  dockerfile-base-pin:
+    name: Dockerfile base-image pinning lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Charter-prose→code gate (noorinalabs-main#735/#744, tech-decisions.md
+      # § Base Image Pinning). Asserts every Dockerfile FROM is digest-pinned
+      # (image:tag@sha256:<digest>) AND carries the matching distro upgrade.
+      # Mirrors the `dockerfile-base-pin` pre-commit hook (the sync-drift gate
+      # classifies the kind, so the mirror is mandatory). Lives in ci.yml (not
+      # docs.yml) so it has no path filter — a Dockerfile-only edit still gates.
+      - name: dockerfile-base-pin — Dockerfile FROM digest-pin + distro upgrade
+        run: |
+          files=$(find . \( -path ./node_modules -o -path ./dist -o -path ./.astro \
+            -o -path ./.claude/worktrees \) -prune -o \
+            \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.dockerfile' \) -print)
+          if [ -z "$files" ]; then
+            echo "No Dockerfiles found — base-pin lint is a no-op here."
+            exit 0
+          fi
+          # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
+          python3 scripts/check_dockerfile_base_pin.py $files

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ yarn-debug.log*
 .eslintcache
 *.tsbuildinfo
 
+# Python (scripts/ CI helpers)
+__pycache__/
+*.pyc
+
 # Logs
 *.log
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,16 @@
 #
 # Stage split (cheapest first, fail-fast):
 #   pre-commit (fast, every commit) — gitleaks, ESLint, Prettier check,
-#     actionlint (workflow lint). Quick checks that catch the most common
-#     defects before a commit is recorded.
+#     actionlint (workflow lint), dockerfile-base-pin (Dockerfile FROM digest
+#     pin + distro upgrade). Quick checks that catch the most common defects
+#     before a commit is recorded.
 #   pre-push   (heavier, every push) — Astro type check, build, unit tests.
 #     These run the whole compile+test surface, so they're push-time not
 #     commit-time to keep the commit loop snappy while still catching
 #     everything before it leaves the machine.
 #
 # The kind-level mirror (eslint, prettier, astro-check, build, actionlint,
-# gitleaks present on both sides) is enforced in CI by
+# gitleaks, dockerfile-base-pin present on both sides) is enforced in CI by
 # `scripts/pre_commit_ci_sync.py` — if a future edit drops a check from one
 # side, that gate (the "Pre-commit <-> CI sync-drift gate" job in docs.yml)
 # fails the build.
@@ -58,6 +59,20 @@ repos:
         entry: bash -c 'npx prettier --check "src/**/*.{ts,tsx,astro,css,md,json}"'
         language: system
         pass_filenames: false
+        stages: [pre-commit]
+
+      # Charter-prose→code gate (noorinalabs-main#735/#744). Lints every
+      # Dockerfile FROM for a digest pin + the matching distro upgrade, mirroring
+      # the `dockerfile-base-pin` CI job (the sync-drift gate classifies the
+      # kind, so this mirror is mandatory). Pure stdlib; commit-stage cheap
+      # static scan. `files` scopes candidates to Dockerfiles; pass_filenames
+      # feeds the matched tracked paths to the checker.
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 scripts/check_dockerfile_base_pin.py
+        language: system
+        files: ((^|/)Dockerfile(\.[^/]+)?$|\.dockerfile$)
+        pass_filenames: true
         stages: [pre-commit]
 
       # Push stage: heavier compile + build + tests (mirror ci.yml Type check,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Stage 1: Build
-FROM node:22-alpine AS build
+# Digest-pinned tag + apk upgrade (base-image pinning gate, noorinalabs-main#735/#744):
+# freezes the layer AND patches within-tag Alpine package drift.
+FROM node:22-alpine@sha256:ab07539e0988b63558ff621f5fbe1077054c39d9809112974fb79993949d41cd AS build
+RUN apk upgrade --no-cache
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 RUN --mount=type=secret,id=npm_token \
@@ -11,7 +14,8 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Production
-FROM nginx:alpine
+FROM nginx:alpine@sha256:1a8724a52d432501548a8d8681bb1554c2d09778f8b9ed0882fc3442549980b7
+RUN apk upgrade --no-cache
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Organization landing page — Astro.
 
-The public marketing site for NoorinALabs: a statically generated Astro + Tailwind site whose pages, layouts, and content collections live under `src/`. It is built to static HTML at deploy time and served from an Nginx container.
+The public marketing site for Noorina Labs: a statically generated Astro + Tailwind site whose pages, layouts, and content collections live under `src/`. It is built to static HTML at deploy time and served from an Nginx container.
 
 ## Git hooks (required)
 
@@ -13,7 +13,7 @@ pre-commit install                       # commit-stage checks
 pre-commit install --hook-type pre-push  # push-stage checks
 ```
 
-- **Commit stage** runs: gitleaks (secret detection), actionlint (workflow lint), ESLint, and Prettier `--check`.
+- **Commit stage** runs: gitleaks (secret detection), actionlint (workflow lint), ESLint, Prettier `--check`, and the Dockerfile base-image-pinning lint (`scripts/check_dockerfile_base_pin.py` — every `FROM` must be digest-pinned with the matching distro upgrade; noorinalabs-main#735/#744).
 - **Pre-push stage** runs: `astro check` (type check), `npm run build`, and unit tests (`npm test`).
 
 The commit stage stays fast so the commit loop is snappy; the heavier compile, build, and test surface runs at push time, before code leaves the machine. Run `npm ci` once after cloning so `node_modules` is present for the local hooks.

--- a/scripts/check_dockerfile_base_pin.py
+++ b/scripts/check_dockerfile_base_pin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Lint Dockerfile `FROM` statements for digest-pin + distro-upgrade compliance.
+
+Deterministic conversion of `.claude/team/charter/tech-decisions.md § Base Image
+Pinning` (noorinalabs-main#735, the charter-prose-inventory worklist item #4 /
+epic #726). The section requires every `FROM` to use a **digest-pinned tag**
+(`image:tag@sha256:<digest>`) **combined with an in-image package upgrade**, to
+close the two failure modes it names — floating-tag drift and within-tag package
+drift (the shape isnad-graph#853 hit).
+
+What this gate enforces (verbatim from the section's distro table)
+================================================================
+For every `FROM` that is not exempt:
+
+1. The image reference MUST carry an `@sha256:` digest pin.
+2. The stage MUST run the package-manager upgrade matching the base distro:
+
+   | Family      | Pin shape               | Upgrade command                                 |
+   |-------------|-------------------------|-------------------------------------------------|
+   | Alpine      | image:tag@sha256:digest | `RUN apk upgrade --no-cache`                    |
+   | Debian-slim | image:tag@sha256:digest | `apt-get update && apt-get -y upgrade && clean` |
+   | Distroless  | image:tag@sha256:digest | none — no package manager (pinned-only is fine) |
+
+   The distro family is inferred from the image name: `alpine` → Alpine,
+   `distroless` → Distroless (no upgrade required), otherwise the glibc/Debian
+   default (an apt upgrade is required). A genuinely-other base that has no
+   package manager should carry the `# RATIONALE:` exemption below.
+
+Exemptions honored (verbatim from the section)
+=============================================
+- **`scratch`** final/any layer — no package manager; the upstream stages that
+  produced its contents still follow the rule and are checked on their own
+  `FROM`.
+- **Distroless** — pinned-only is sufficient (no package manager); the digest
+  pin is still required.
+- **Multi-stage stage reference** — a `FROM <earlier-stage>` inherits the
+  upstream stage's pin, so it is not re-checked (the named stage was checked at
+  its defining `FROM`).
+- **Vendor images** documented with an inline `# RATIONALE:` comment on the
+  `FROM` line (or the comment line immediately above it).
+
+CLI
+===
+    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+
+Exit codes:
+    0 — every FROM in every file is compliant (or exempt)
+    1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
+    2 — usage / file-not-found error
+
+This is a reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
+pre-commit config and its CI. The parent repo `noorinalabs-main` ships no
+Dockerfiles itself; the cross-repo rollout that points this at each child's
+Dockerfiles is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
+# A leading `--platform=...` flag precedes the image and must be stripped.
+_PLATFORM_RE = re.compile(r"^--platform=\S+\s+", re.IGNORECASE)
+# A trailing `AS <stage>` names the build stage.
+_AS_RE = re.compile(r"\s+AS\s+(?P<stage>\S+)\s*$", re.IGNORECASE)
+
+# Upgrade-command signatures per distro family (searched over the stage body).
+_ALPINE_UPGRADE_RE = re.compile(r"\bapk\s+upgrade\b", re.IGNORECASE)
+# `apt-get update && apt-get -y upgrade` / `apt upgrade` — an apt invocation
+# followed (in the same command segment) by `upgrade`. `apt-get update` alone
+# does NOT match (that is "update", not "upgrade").
+_DEBIAN_UPGRADE_RE = re.compile(r"\bapt(?:-get)?\s+(?:-{1,2}\S+\s+)*upgrade\b", re.IGNORECASE)
+
+_RATIONALE_RE = re.compile(r"#\s*RATIONALE:", re.IGNORECASE)
+
+
+class FromStatement:
+    """One parsed `FROM` line: its image ref, optional stage name, exemptions."""
+
+    def __init__(self, lineno: int, image: str, stage: str | None, has_rationale: bool) -> None:
+        self.lineno = lineno
+        self.image = image
+        self.stage = stage
+        self.has_rationale = has_rationale
+
+
+def _preceding_comment_has_rationale(lines: list[str], from_idx: int) -> bool:
+    """True if the comment line(s) immediately above `from_idx` carry RATIONALE."""
+    j = from_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if stripped.startswith("#"):
+            return bool(_RATIONALE_RE.search(stripped))
+        return False
+    return False
+
+
+def parse_froms(text: str) -> list[FromStatement]:
+    """Parse every `FROM` statement in a Dockerfile, in source order."""
+    lines = text.splitlines()
+    froms: list[FromStatement] = []
+    for idx, raw in enumerate(lines):
+        m = _FROM_RE.match(raw)
+        if not m:
+            continue
+        rest = m.group("rest")
+        has_rationale = bool(_RATIONALE_RE.search(raw)) or _preceding_comment_has_rationale(
+            lines, idx
+        )
+        # Drop any trailing inline comment, then a leading --platform flag.
+        code = rest.split("#", 1)[0].strip()
+        code = _PLATFORM_RE.sub("", code).strip()
+        stage: str | None = None
+        as_m = _AS_RE.search(code)
+        if as_m is not None:
+            stage = as_m.group("stage")
+            code = code[: as_m.start()].strip()
+        image = code.split()[0] if code.split() else ""
+        froms.append(FromStatement(idx + 1, image, stage, has_rationale))
+    return froms
+
+
+def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
+    """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
+    lines = text.splitlines()
+    start = from_lineno  # from_lineno is 1-based; body starts on the next line
+    end = (next_from_lineno - 1) if next_from_lineno is not None else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def check_dockerfile_text(path: str, text: str) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile."""
+    violations: list[str] = []
+    froms = parse_froms(text)
+    defined_stages: set[str] = set()
+    for i, stmt in enumerate(froms):
+        next_lineno = froms[i + 1].lineno if i + 1 < len(froms) else None
+        image_l = stmt.image.lower()
+
+        # Exemptions, in order. `scratch` and stage-references have no package
+        # manager / inherit the upstream pin; a documented vendor RATIONALE opts
+        # out explicitly. Record this stage's own name for later references.
+        is_exempt = image_l == "scratch" or image_l in defined_stages or stmt.has_rationale
+        if stmt.stage:
+            defined_stages.add(stmt.stage.lower())
+        if is_exempt:
+            continue
+
+        if "@sha256:" not in stmt.image:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
+                f"(require image:tag@sha256:<digest>)"
+            )
+
+        body = _stage_body(text, stmt.lineno, next_lineno)
+        if "distroless" in image_l:
+            continue  # distroless has no package manager; pinned-only is sufficient
+        if "alpine" in image_l:
+            if not _ALPINE_UPGRADE_RE.search(body):
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Alpine upgrade "
+                    f"step (RUN apk upgrade --no-cache)"
+                )
+        elif not _DEBIAN_UPGRADE_RE.search(body):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Debian upgrade step "
+                f"(RUN apt-get update && apt-get -y upgrade && apt-get clean)"
+            )
+    return violations
+
+
+def check_file(path: Path) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
+            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
+            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
+            "an inline `# RATIONALE:` comment on the FROM line."
+        )
+        return 1
+
+    print("OK: all Dockerfile FROM statements are digest-pinned with the required upgrade.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/pre_commit_ci_sync.py
+++ b/scripts/pre_commit_ci_sync.py
@@ -23,7 +23,8 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    dockerfile-base-pin
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -64,6 +65,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build", "docker build"),
+    # `dockerfile-base-pin` is the charter-prose→code base-image gate
+    # (noorinalabs-main#735/#744): a `scripts/check_dockerfile_base_pin.py` run
+    # invoked identically by a CI job and a pre-commit hook. Classifying it makes
+    # the sync-drift gate DEMAND the mirror (#684) — a CI base-pin job with no
+    # pre-commit hook is harmful drift, not a silently-ignored unknown. Patterns
+    # match the script basename (present on both sides' invoke line) and the
+    # hook id / job name.
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also


### PR DESCRIPTION
## What & why

Landing-page slice of the cross-repo rollout (parent **noorinalabs-main#744 + #718**). Landing-page ships a Dockerfile (multi-stage Node → Nginx Alpine), so the base-image-pinning gate applies here. There are no Arabic fixtures in this repo, so the sibling `fixture-realism` gate is **N/A** (scoped out).

Closes #153

## Changes

**#744 — Dockerfile base-pin gate**
- `scripts/check_dockerfile_base_pin.py` — canonical copy of the parent `noorinalabs-main` check: every `FROM` must be digest-pinned (`image:tag@sha256:…`) AND carry the matching distro upgrade.
- `.github/workflows/ci.yml` — new `dockerfile-base-pin` job. Lives in `ci.yml` (not `docs.yml`) so it has **no path filter** — a Dockerfile-only edit still gates. The step name leads with the `dockerfile-base-pin` token so the repo's line-scanner classifier detects it.
- `.pre-commit-config.yaml` — new commit-stage `dockerfile-base-pin` hook.
- `scripts/pre_commit_ci_sync.py` — taught the `dockerfile-base-pin` kind so the `Pre-commit ⇄ CI sync-drift gate` now DEMANDS the local⇄CI mirror (#684) instead of silently ignoring it.
- `Dockerfile` — **fix-forward**: digest-pinned `node:22-alpine` and `nginx:alpine` (digests resolved via `docker buildx imagetools inspect`) and added `RUN apk upgrade --no-cache` to each Alpine stage.

**#718 — local-hooks README docs**
- Extended the README commit-stage hook list to include the Dockerfile base-pin lint.
- Fixed the `NoorinALabs` → `Noorina Labs` brand typo (#792).

**Housekeeping**
- `.gitignore` — ignore Python bytecode now that `scripts/` carries `.py` helpers.

## Verification
- `scripts/check_dockerfile_base_pin.py Dockerfile` → OK (both FROMs pinned + upgraded).
- `scripts/pre_commit_ci_sync.py .` → green; `dockerfile-base-pin` now classified on both sides; no harmful drift.
- `actionlint` v1.7.12 (CI-pinned, shellcheck present) on `ci.yml` + `docs.yml` → clean.
- Full pre-commit (commit + pre-push stages) green: gitleaks, actionlint, prettier, dockerfile-base-pin, astro-check, build, unit-tests.

## Reviewers
- Peer review — Cédric Novák (UX/Visual Designer)
- Secondary review — Marcia Vasquez-Paredes (Project Lead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7PudS35xmg2FW6tJekTGP
